### PR TITLE
Fix volatile msg bug

### DIFF
--- a/halagent.py
+++ b/halagent.py
@@ -9,7 +9,8 @@ class HalAgent():
 	def init(self):
 		pass
 
-	def send(self, msg):
+	def send(self, msg0):
+		msg = msg0.copy()
 		msg["source"] = "agent"
 		self._hal.receive(msg)
 

--- a/halmodule.py
+++ b/halmodule.py
@@ -9,14 +9,17 @@ class HalModule():
 	def init(self):
 		pass
 
-	def send(self, msg):
+	def send(self, msg0):
+		msg = msg0.copy()
 		msg["source"] = "module"
 		self._hal.receive(msg)
 
 	def receive(self, msg):
 		pass
 
-	def reply(self, msg, body=""):
+	def reply(self, msg0, body=""):
+		# this does a double copy :(
+		msg = msg0.copy()
 		msg["body"] = body
 
 		self.send(msg)


### PR DESCRIPTION
There was a bug where previous modules modified the messages for the
following modules. This commit introduces .copy() for all of the places
where msg vars are modified. An alternative would perhaps be to give
each module instance its own copy.

There is perhaps a better way to do this than either though.
