### PR TITLE
Added rudimentary Halibot reloading support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,40 @@
 #!/usr/bin/env python3
 
-import halibot
+import halibot, imp
+
+# Reloads the halibot core, does not reinitialize modules/agents
+#  Takes in old bot instances, returns new bot
+def hal_reload(bot):
+	global halibot
+	halibot = imp.reload(halibot)
+
+	newbot = halibot.Halibot()
+
+	newbot.config = bot.config
+	newbot.agents = bot.agents
+	newbot.modules = bot.modules
+	newbot.queue = bot.queue
+
+	newbot.running = True
+	newbot._start_route()
+	return newbot
 
 def main():
 	bot = halibot.Halibot()
 	bot.start(block=True)
+
+	# Keeps reloading halibot if rld is set to True
 	while True:
-		pass
+		while bot.running:
+			pass
+
+		# Put this is a deinit?
+		bot.thread.join()
+
+		if bot.rld:
+			bot = hal_reload(bot)
+		else:
+			break
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Bunch of changes in this, probably should have separated into more comments, PRs. Sorry.
1. Reordered and fixed some of the preample in `halibot.py`.
2. Fixed a bug where the routing thread never terminates properly (needs to be `.join()`ed)
3. Added a function main.py to recreate a halibot object:
   - Reloads the `halibot` python module
   - Creates a new one
   - Copies over the Queue, Agents, Modules, and Config
   - Starts the new routing thread
4. Added a `running` state the Halibot object, the `_do_route()` function now spins on this rather than `True`
5. Added a `rld` "reload" state. Currently, nothing touches this; this is something a module should manipulate. For telling the `main()` function to reload halibot and not quit
6. `Halibot.start()` now properly handles the optional kwarg `block`, and will block on `self.thread.join()` if set to `True` (the default)
   - Note: The target for `self.thread` should terminate when `self.running` is set to False, something a module should do.

Implements issue #2
