### PR TITLE
Initial channel implemtation

### DIFF
--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -34,6 +34,14 @@ class IrcAgent(HalAgent):
 	def receive(self, msg):
 		self.client.message(msg["context"]["whom"], msg["body"])
 
+
+	def shutdown(self):
+		super(IrcAgent, self).shutdown()
+
+		self.client.disconnect()
+		self.client.eventloop.stop()
+		self.thread.join()
+
 	# Start the thread the IRC client will live in
 	#  This is so the client does not block on halibot's instantiation (main) thread,
 	#  thus causing to stop there and never finish starting up

--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -36,8 +36,6 @@ class IrcAgent(HalAgent):
 
 
 	def shutdown(self):
-		super(IrcAgent, self).shutdown()
-
 		self.client.disconnect()
 		self.client.eventloop.stop()
 		self.thread.join()

--- a/halagent.py
+++ b/halagent.py
@@ -4,11 +4,5 @@ class HalAgent(HalObject):
 
 	def send(self, msg):
 		out = self.config.get('out', self._hal.modules.keys())
-
-		for name in out:
-			to = self._hal.get_object(name)
-			if to:
-				to._queue_msg(msg)
-			else:
-				self.log.warning('Unknown module/agent: ' + str(name))
+		self.send_to(msg, out)
 

--- a/halagent.py
+++ b/halagent.py
@@ -1,23 +1,14 @@
-import logging
+from halobject import HalObject
 
-class HalAgent():
-	
-	_hal = None
+class HalAgent(HalObject):
 
-	def __init__(self, hal, conf):
-		self._hal = hal
-		self.config = conf
-		self.log = logging.getLogger(self.__class__.__name__) # TODO: Put instantiated name in here
+	def send(self, msg):
+		out = self.config.get('out', self._hal.modules.keys())
 
-	def init(self):
-		pass
+		for name in out:
+			to = self._hal.get_object(name)
+			if to:
+				to._queue_msg(msg)
+			else:
+				self.log.warning('Unknown module/agent: ' + str(name))
 
-	def send(self, msg0):
-		self.log.debug("Sending to base: " + str(msg0))
-		msg = msg0.copy()
-		msg["source"] = "agent"
-		self._hal.receive(msg)
-
-	def receive(self, msg):
-		self.log.debug("Received from base: " + str(msg0))
-		pass

--- a/halibot.py
+++ b/halibot.py
@@ -43,9 +43,9 @@ class Halibot():
 		self.log.info("Shutting down halibot...");
 
 		for m in self.modules.values():
-			m.shutdown()
+			m._shutdown()
 		for a in self.agents.values():
-			a.shutdown()
+			a._shutdown()
 
 		self.log.info("Halibot shutdown. Threads left: " + str(threading.active_count()))
 

--- a/halibot.py
+++ b/halibot.py
@@ -39,11 +39,6 @@ class Halibot():
 		self._instantiate_agents()
 		self._instantiate_modules()
 
-		self._start_route()
-
-		if block:
-			self.thread.join()
-
 	def _load_config(self):
 		with open("config.json","r") as f:
 			self.config = json.loads(f.read())
@@ -81,25 +76,9 @@ class Halibot():
 			self.modules[k].init()
 			self.log.info("Instantiated module '" + k + "'")
 
+	def get_object(self, name):
+		# TODO priority?
+		if name in self.modules: return self.modules[name]
+		if name in self.agents: return self.agents[name]
+		return None
 
-	def _start_route(self):
-		self.thread = threading.Thread(target=self._do_route)
-
-		self.thread.start()
-
-
-	def _do_route(self):
-		while self.running:
-			try:
-				m = self.queue.get(block=True, timeout=5)
-			except Empty:
-				continue
-
-			if m["source"] == "module":
-				self.agents[m["context"]["agent"]].receive(m)
-			elif m["source"] == "agent":
-				for a in self.modules.values():
-					a.receive(m)
-
-	def receive(self, msg):
-		self.queue.put(msg)

--- a/halibot.py
+++ b/halibot.py
@@ -39,6 +39,16 @@ class Halibot():
 		self._instantiate_agents()
 		self._instantiate_modules()
 
+	def shutdown(self):
+		self.log.info("Shutting down halibot...");
+
+		for m in self.modules.values():
+			m.shutdown()
+		for a in self.agents.values():
+			a.shutdown()
+
+		self.log.info("Halibot shutdown. Threads left: " + str(threading.active_count()))
+
 	def _load_config(self):
 		with open("config.json","r") as f:
 			self.config = json.loads(f.read())

--- a/halmodule.py
+++ b/halmodule.py
@@ -1,30 +1,13 @@
-import logging
+from halobject import HalObject
 
-class HalModule():
-	
-	_hal = None
-	log = None
+class HalModule(HalObject):
 
-	def __init__(self, hal, conf):
-		self._hal = hal
-		self.config = conf
-		self.log = logging.getLogger(self.__class__.__name__) # TODO: Put instantiated name in here too
+	def send(self, msg):
+		out = self.config.get('out', [ msg['context']['agent'] ])
 
-	def init(self):
-		pass
-
-	def send(self, msg0):
-		self.log.debug("Sending to base: " + str(msg0))
-		msg = msg0.copy()
-		msg["source"] = "module"
-		self._hal.receive(msg)
-
-	def receive(self, msg):
-		self.log.debug("Received from base: " + str(msg0))
-
-	def reply(self, msg0, body=""):
-		# this does a double copy :(
-		msg = msg0.copy()
-		msg["body"] = body
-
-		self.send(msg)
+		for name in out:
+			to = self._hal.get_object(name)
+			if to:
+				to._queue_msg(msg)
+			else:
+				self.log.warning('Unknown module/agent: ' + str(name))

--- a/halmodule.py
+++ b/halmodule.py
@@ -4,10 +4,5 @@ class HalModule(HalObject):
 
 	def send(self, msg):
 		out = self.config.get('out', [ msg['context']['agent'] ])
+		self.send_to(msg, out)
 
-		for name in out:
-			to = self._hal.get_object(name)
-			if to:
-				to._queue_msg(msg)
-			else:
-				self.log.warning('Unknown module/agent: ' + str(name))

--- a/halobject.py
+++ b/halobject.py
@@ -27,6 +27,14 @@ class HalObject():
 	def send(self, msg):
 		pass
 
+	def send_to(self, msg, dests):
+		for name in dests:
+			to = self._hal.get_object(name)
+			if to:
+				to._queue_msg(msg)
+			else:
+				self.log.warning('Unknown module/agent: ' + str(name))
+
 	def receive(self, msg):
 		self.log.debug("Received from base: " + str(msg))
 		pass

--- a/halobject.py
+++ b/halobject.py
@@ -1,5 +1,5 @@
 import logging
-from queue import Queue
+import asyncio
 from threading import Thread
 
 class HalObject():
@@ -9,18 +9,12 @@ class HalObject():
 		self.config = conf
 		self.log = logging.getLogger(self.__class__.__name__) # TODO: Put instantiated name in here too
 
-		self._msg_queue = Queue()
-		self._thread = Thread(target=self._spin)
+		self.eventloop = asyncio.SelectorEventLoop()
+		self._thread = Thread(target=self.eventloop.run_forever)
 		self._thread.start()
 
-	def _spin(self):
-		while True:
-			m = self._msg_queue.get()
-			self.receive(m)
-			self._msg_queue.task_done()
-
 	def _queue_msg(self, msg):
-		self._msg_queue.put(msg.copy())
+		self.eventloop.call_soon_threadsafe(self.receive, msg.copy())
 
 	def init(self):
 		pass

--- a/halobject.py
+++ b/halobject.py
@@ -13,6 +13,11 @@ class HalObject():
 		self._thread = Thread(target=self.eventloop.run_forever)
 		self._thread.start()
 
+	def _shutdown(self):
+		self.eventloop.call_soon_threadsafe(self.eventloop.stop)
+		self._thread.join()
+		self.shutdown()
+
 	def _queue_msg(self, msg):
 		self.eventloop.call_soon_threadsafe(self.receive, msg.copy())
 
@@ -20,8 +25,7 @@ class HalObject():
 		pass
 
 	def shutdown(self):
-		self.eventloop.call_soon_threadsafe(self.eventloop.stop)
-		self._thread.join()
+		pass
 
 	# See halmodule and halagent for their respective implementations
 	def send(self, msg):

--- a/halobject.py
+++ b/halobject.py
@@ -1,0 +1,35 @@
+import logging
+from queue import Queue
+from threading import Thread
+
+class HalObject():
+
+	def __init__(self, hal, conf):
+		self._hal = hal
+		self.config = conf
+		self.log = logging.getLogger(self.__class__.__name__) # TODO: Put instantiated name in here too
+
+		self._msg_queue = Queue()
+		self._thread = Thread(target=self._spin)
+		self._thread.start()
+
+	def _spin(self):
+		while True:
+			m = self._msg_queue.get()
+			self.receive(m)
+			self._msg_queue.task_done()
+
+	def _queue_msg(self, msg):
+		self._msg_queue.put(msg.copy())
+
+	def init(self):
+		pass
+
+	# See halmodule and halagent for their respective implementations
+	def send(self, msg):
+		pass
+
+	def receive(self, msg):
+		self.log.debug("Received from base: " + str(msg))
+		pass
+

--- a/halobject.py
+++ b/halobject.py
@@ -19,6 +19,10 @@ class HalObject():
 	def init(self):
 		pass
 
+	def shutdown(self):
+		self.eventloop.call_soon_threadsafe(self.eventloop.stop)
+		self._thread.join()
+
 	# See halmodule and halagent for their respective implementations
 	def send(self, msg):
 		pass

--- a/main.py
+++ b/main.py
@@ -4,40 +4,10 @@ import halibot
 import imp
 import logging
 
-# Reloads the halibot core, does not reinitialize modules/agents
-#  Takes in old bot instances, returns new bot
-def hal_reload(bot):
-	global halibot
-	halibot = imp.reload(halibot)
-
-	newbot = halibot.Halibot()
-
-	newbot.config = bot.config
-	newbot.agents = bot.agents
-	newbot.modules = bot.modules
-	newbot.queue = bot.queue
-
-	newbot.running = True
-	newbot._start_route()
-	return newbot
-
 def main():
 	logging.basicConfig(level=logging.DEBUG)
 	bot = halibot.Halibot()
 	bot.start(block=True)
-
-	# Keeps reloading halibot if rld is set to True
-	while True:
-		while bot.running:
-			pass
-
-		# Put this is a deinit?
-		bot.thread.join()
-
-		if bot.rld:
-			bot = hal_reload(bot)
-		else:
-			break
 
 if __name__ == "__main__":
 	main()

--- a/modules/hello/hello.py
+++ b/modules/hello/hello.py
@@ -25,7 +25,8 @@ class Hello(HalModule):
 		# The "body" field should always be populated, thus this is a safe assumption.(otherwise, an agent isn't working properly!
 		if msg["body"].startswith("!hello"):
 			# Send a message back to the sender, using the same method that was used to receive it
-			self.reply(msg, body="Hello world!")
+			msg["body"] = "Hello world!"
+			self.send(msg)
 
 	# NOTE: The HalModule also includes a send() method, which reply() calls out to
 	#  reply() is the same as send()'ing a copy of the received message, with a new body


### PR DESCRIPTION
I submit this PR tentatively. The remove of the reply method makes the `hello` module a little more funky. I would ideally like a spiffy `Message` class with helpful builders and all that jazz.

The HalObject class is added here which abstracts the idea of a module or an agent. HalModule and HalAgent only differ in send behavoir, more specifically send behavoir when out channels are not specified.

Module/agent instance configs can now contain an 'out' field which is a list of names of objects to send the output of the module to (via send). The absence of this invokes the default behavoir (send to all modules for agents, the agent specified in the message for modules).

Resolves #17.

**Note this is backwards incompatible as it removes the `reply` method.**
