### PR TITLE
Flat model implementation and Message/Context objects

### DIFF
--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -79,4 +79,4 @@ class IrcClient(pydle.Client):
 		msg = Message(body=text, author=by, context=cxt)
 
 		# Send the Halibot-friendly message to the Halibot base for module processing
-		self.agent.send(msg)
+		self.agent.dispatch(msg)

--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -2,7 +2,7 @@
 # Reference Halibot IRC Agent
 #  Connects to an IRC server and relays messages to and from the base
 #
-from halibot import HalAgent
+from halibot import HalAgent, Context, Message
 import pydle, threading
 
 # Haliot Reference IRC Agent
@@ -32,7 +32,7 @@ class IrcAgent(HalAgent):
 	#  In this case, the logic for sending a message to the IRC channel is put here,
 	#  using the "context" of the message to know where to send it.
 	def receive(self, msg):
-		self.client.message(msg["context"]["whom"], msg["body"])
+		self.client.message(msg.context.whom, msg.body)
 
 
 	def shutdown(self):
@@ -75,15 +75,8 @@ class IrcClient(pydle.Client):
 	#  The purpose of this agent is to communicate with IRC,
 	#  so this repackages the message from Pydle into a Halibot-friendly message
 	def on_channel_message(self, target, by, text):
-		msg = {}
-
-		msg["body"] = text
-		msg["type"] = "message"
-		msg["author"] = by
-		msg["context"] = {}
-		msg["context"]["agent"] = self.agent.name
-		msg["context"]["protocol"] = "irc"
-		msg["context"]["whom"] = target
+		cxt = Context(agent=self.agent.name, protocol='irc', whom=target)
+		msg = Message(body=text, author=by, context=cxt)
 
 		# Send the Halibot-friendly message to the Halibot base for module processing
 		self.agent.send(msg)

--- a/halibot/__init__.py
+++ b/halibot/__init__.py
@@ -1,3 +1,4 @@
 from .halibot import Halibot
 from .halagent import HalAgent
 from .halmodule import HalModule
+from .message import Context, Message

--- a/halibot/halagent.py
+++ b/halibot/halagent.py
@@ -2,7 +2,14 @@ from .halobject import HalObject
 
 class HalAgent(HalObject):
 
-	def send(self, msg):
+	def dispatch(self, msg):
 		out = self.config.get('out', self._hal.modules.keys())
 		self.send_to(msg, out)
+
+	def connect(self, to):
+		# FIXME Don't modify the config like this?
+		if 'out' in self.config:
+			self.config['out'].append(to.name)
+		else:
+			self.config['out'] = [ to.name ]
 

--- a/halibot/halmodule.py
+++ b/halibot/halmodule.py
@@ -1,8 +1,15 @@
 from .halobject import HalObject
+from .message import Message
 
 class HalModule(HalObject):
 
-	def send(self, msg):
-		out = self.config.get('out', [ msg.context.agent ])
-		self.send_to(msg, out)
+	def reply(self, msg0=None, **kwargs):
+		body = kwargs.get('body', msg0.body)
+		mtype = kwargs.get('type', msg0.type)
+		author = kwargs.get('author', msg0.author)
+		context = kwargs.get('context', msg0.context)
+
+		msg = Message(body=body, type=mtype, author=author, context=context)
+
+		self.send_to(msg, [ msg.context.agent ])
 

--- a/halibot/halmodule.py
+++ b/halibot/halmodule.py
@@ -3,6 +3,6 @@ from .halobject import HalObject
 class HalModule(HalObject):
 
 	def send(self, msg):
-		out = self.config.get('out', [ msg['context']['agent'] ])
+		out = self.config.get('out', [ msg.context.agent ])
 		self.send_to(msg, out)
 

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -19,7 +19,7 @@ class HalObject():
 		self.shutdown()
 
 	def _queue_msg(self, msg):
-		self.eventloop.call_soon_threadsafe(self.receive, msg.copy())
+		self.eventloop.call_soon_threadsafe(self.receive, msg)
 
 	def init(self):
 		pass

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -42,11 +42,3 @@ class HalObject():
 	def receive(self, msg):
 		self.log.debug("Received from base: " + str(msg))
 		pass
-
-	def connect(self, to):
-		# FIXME Don't modify the config like this?
-		if 'out' in self.config:
-			self.config['out'].append(to.name)
-		else:
-			self.config['out'] = [ to.name ]
-

--- a/halibot/jsdict.py
+++ b/halibot/jsdict.py
@@ -1,0 +1,7 @@
+
+class jsdict(dict):
+	def __getattr__(self, name):
+		return self[name]
+
+	def __setattr__(self, name, value):
+		self[name] = value

--- a/halibot/message.py
+++ b/halibot/message.py
@@ -1,0 +1,18 @@
+from .jsdict import jsdict
+
+class Context():
+	
+	def __init__(self, **kwargs):
+		self.agent = kwargs.get('agent', None)
+		self.protocol = kwargs.get('protocol', None)
+		self.whom = kwargs.get('whom', None)
+
+class Message():
+
+	def __init__(self, **kwargs):
+		self.body = kwargs.get('body', None)
+		self.type = kwargs.get('type', 'simple')
+		self.author = kwargs.get('author', None)
+		self.context = kwargs.get('context', Context())
+		self.misc = kwargs.get('misc', jsdict())
+

--- a/modules/hello/hello.py
+++ b/modules/hello/hello.py
@@ -25,7 +25,7 @@ class Hello(HalModule):
 		# The "body" field should always be populated, thus this is a safe assumption.(otherwise, an agent isn't working properly!
 		if msg.body.startswith("!hello"):
 			# Send a message back to the sender, using the same method that was used to receive it
-			self.send(Message(body="Hello world!", context=msg.context))
+			self.reply(msg, body="Hello world!")
 
 	# NOTE: The HalModule also includes a send() method, which reply() calls out to
 	#  reply() is the same as send()'ing a copy of the received message, with a new body

--- a/modules/hello/hello.py
+++ b/modules/hello/hello.py
@@ -2,7 +2,7 @@
 # Hello World reference Halibot Module
 #  Replies to any message starting with "!hello"
 #
-from halibot import HalModule
+from halibot import HalModule, Message
 
 # Hello Module
 #  Upon receiving a message from any source, checks if the body of that message
@@ -23,10 +23,9 @@ class Hello(HalModule):
 	#  To where it comes from, check the "context" field.
 	def receive(self, msg):
 		# The "body" field should always be populated, thus this is a safe assumption.(otherwise, an agent isn't working properly!
-		if msg["body"].startswith("!hello"):
+		if msg.body.startswith("!hello"):
 			# Send a message back to the sender, using the same method that was used to receive it
-			msg["body"] = "Hello world!"
-			self.send(msg)
+			self.send(Message(body="Hello world!", context=msg.context))
 
 	# NOTE: The HalModule also includes a send() method, which reply() calls out to
 	#  reply() is the same as send()'ing a copy of the received message, with a new body

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,12 +21,6 @@ class StubAgent(halibot.HalAgent):
 	def init(self):
 		self.inited = True
 
-# TODO remove and use actual message builder/constructor
-def make_test_msg(body):
-	return {
-		'body': body,
-	}
-
 class TestCore(util.HalibotTestCase):
 
 	def test_add_module(self):
@@ -49,14 +43,14 @@ class TestCore(util.HalibotTestCase):
 		self.bot.add_agent_instance('stub_agent', agent)
 		self.bot.add_module_instance('stub_mod', mod)
 
-		foo = make_test_msg('foo')
-		bar = make_test_msg('bar')
-		baz = make_test_msg('baz')
+		foo = halibot.Message(body='foo')
+		bar = halibot.Message(body='bar')
+		baz = halibot.Message(body='baz')
 
 		agent.connect(mod)
-		agent.send(foo)
+		agent.dispatch(foo)
 		agent.send_to(bar, [ 'stub_mod' ])
-		agent.send(baz)
+		agent.dispatch(baz)
 
 		# TODO do something sensible here
 		timeout = 10


### PR DESCRIPTION
Still need named objects though.

The `send` function was removed and replaced by a `dispatch` for agents and a `reply` for modules that reflect the intended use of send in the previous model. This is open to dispute, though.
