### PR TITLE
Contain implementation

### DIFF
--- a/agents/agentcontainer/agentcontainer.py
+++ b/agents/agentcontainer/agentcontainer.py
@@ -1,0 +1,7 @@
+from halibot import HalAgent
+
+class AgentContainer(HalAgent):
+
+	def receive(self, msg):
+		self.send_to(msg, self.config.get('contents', []))
+

--- a/agents/agentcontainer/config.json
+++ b/agents/agentcontainer/config.json
@@ -1,0 +1,3 @@
+{
+  "main": "agentcontainer.py"
+}

--- a/modules/modulecontainer/config.json
+++ b/modules/modulecontainer/config.json
@@ -1,0 +1,3 @@
+{
+  "main": "modulecontainer.py"
+}

--- a/modules/modulecontainer/modulecontainer.py
+++ b/modules/modulecontainer/modulecontainer.py
@@ -1,0 +1,7 @@
+from halibot import HalModule
+
+class ModuleContainer(HalModule):
+
+	def receive(self, msg):
+		self.send_to(msg, self.config.get('contents', []))
+


### PR DESCRIPTION
This is the extremely simple implementation of containers. I would like them to be exposed so that the classes can be inherited from, but at the moment it is probably not a big deal, and should probably be solved by allowing packages to expose classes rather than the other option of moving the container classes into the base.

This implementation does allow for a container to contain itself, which while not nonsensical, certainly does not lead to anything good, as in it will most definitely cause an infinite loop. There is, however, no easy way to solve this, even if we check for a container containing itself there still could be a loop of containers in the flow, so the problem is not alleviated. We could perhaps prevent this by attaching a list of visited containers to the message. I am not sure if that is the ideal solution though.
