### PR TITLE
Resource identifiers

### DIFF
--- a/agents/agentcontainer/agentcontainer.py
+++ b/agents/agentcontainer/agentcontainer.py
@@ -2,6 +2,8 @@ from halibot import HalAgent
 
 class AgentContainer(HalAgent):
 
-	def receive(self, msg):
-		self.send_to(msg, self.config.get('contents', []))
+	def receive(self, msg, whom):
+		suff = '/' + whom if whom != '' else ''
+		cont = self.config.get('contents', [])
+		self.send_to(msg, [ name + suff for name in cont ])
 

--- a/agents/agentcontainer/agentcontainer.py
+++ b/agents/agentcontainer/agentcontainer.py
@@ -2,8 +2,8 @@ from halibot import HalAgent
 
 class AgentContainer(HalAgent):
 
-	def receive(self, msg, whom):
-		suff = '/' + whom if whom != '' else ''
+	def receive(self, msg):
+		suff = '/' + msg.whom() if msg.whom() != '' else ''
 		cont = self.config.get('contents', [])
 		self.send_to(msg, [ name + suff for name in cont ])
 

--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -30,10 +30,10 @@ class IrcAgent(HalAgent):
 	# Implement the receive() function as defined in the HalModule class
 	#  This is called when the Halibot wants to send a message out using this agent.
 	#  In this case, the logic for sending a message to the IRC channel is put here,
-	#  using the "channel" arguement, which is the tail end of the resource
+	#  using the whom as the "channel", which is the tail end of the resource
 	#  identifier for this target (e.g. the "#foo" in "irc/#foo").
-	def receive(self, msg, channel):
-		self.client.message(channel, msg.body)
+	def receive(self, msg):
+		self.client.message(msg.whom(), msg.body)
 
 
 	def shutdown(self):

--- a/agents/irc/irc.py
+++ b/agents/irc/irc.py
@@ -30,9 +30,10 @@ class IrcAgent(HalAgent):
 	# Implement the receive() function as defined in the HalModule class
 	#  This is called when the Halibot wants to send a message out using this agent.
 	#  In this case, the logic for sending a message to the IRC channel is put here,
-	#  using the "context" of the message to know where to send it.
-	def receive(self, msg):
-		self.client.message(msg.context.whom, msg.body)
+	#  using the "channel" arguement, which is the tail end of the resource
+	#  identifier for this target (e.g. the "#foo" in "irc/#foo").
+	def receive(self, msg, channel):
+		self.client.message(channel, msg.body)
 
 
 	def shutdown(self):
@@ -75,8 +76,8 @@ class IrcClient(pydle.Client):
 	#  The purpose of this agent is to communicate with IRC,
 	#  so this repackages the message from Pydle into a Halibot-friendly message
 	def on_channel_message(self, target, by, text):
-		cxt = Context(agent=self.agent.name, protocol='irc', whom=target)
-		msg = Message(body=text, author=by, context=cxt)
+		org = self.agent.name + '/' + target
+		msg = Message(body=text, author=by, origin=org)
 
 		# Send the Halibot-friendly message to the Halibot base for module processing
 		self.agent.dispatch(msg)

--- a/halibot/halmodule.py
+++ b/halibot/halmodule.py
@@ -7,9 +7,13 @@ class HalModule(HalObject):
 		body = kwargs.get('body', msg0.body)
 		mtype = kwargs.get('type', msg0.type)
 		author = kwargs.get('author', msg0.author)
-		context = kwargs.get('context', msg0.context)
+		origin = kwargs.get('origin', msg0.origin)
 
-		msg = Message(body=body, type=mtype, author=author, context=context)
+		msg = Message(body=body, type=mtype, author=author, origin=origin)
 
-		self.send_to(msg, [ msg.context.agent ])
+		# For deprecation, remove for 1.0
+		if 'context' in kwargs:
+			msg.context = kwargs['context']
+
+		self.send_to(msg, [ msg.origin ])
 

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import inspect
 from threading import Thread
 
 class HalObject():
@@ -18,8 +19,15 @@ class HalObject():
 		self._thread.join()
 		self.shutdown()
 
-	def _queue_msg(self, msg):
-		self.eventloop.call_soon_threadsafe(self.receive, msg)
+	def _queue_msg(self, msg, whom):
+		self.eventloop.call_soon_threadsafe(self._receive, msg, whom)
+
+	# Calls receive() with the proper number of arguments
+	def _receive(self, msg, whom):
+		if len(inspect.getargspec(self.receive).args) == 2:
+			self.receive(msg)
+		else:
+			self.receive(msg, whom)
 
 	def init(self):
 		pass
@@ -28,13 +36,16 @@ class HalObject():
 		pass
 
 	def send_to(self, msg, dests):
-		for name in dests:
+		for ri in dests:
+			name = ri.split('/')[0]
+			whom = '/'.join(ri.split('/')[1:])
 			to = self._hal.get_object(name)
 			if to:
-				to._queue_msg(msg)
+				to._queue_msg(msg, whom)
 			else:
 				self.log.warning('Unknown module/agent: ' + str(name))
 
-	def receive(self, msg):
+	def receive(self, msg, whom):
 		self.log.debug("Received from base: " + str(msg))
 		pass
+

--- a/halibot/message.py
+++ b/halibot/message.py
@@ -1,5 +1,7 @@
+import logging
 from .jsdict import jsdict
 
+# Deprecated, remove at 1.0
 class Context():
 	
 	def __init__(self, **kwargs):
@@ -7,12 +9,53 @@ class Context():
 		self.protocol = kwargs.get('protocol', None)
 		self.whom = kwargs.get('whom', None)
 
+	def __setattr__(self, key, value):
+		object.__setattr__(self, key, value)
+
+		if 'message' in dir(self):
+			self.message.log.warning('Deprecated use of "context" field on Message object')
+			object.__setattr__(self.message, 'origin', self.makeOrigin())
+
+	def makeOrigin(self):
+		if self.agent == None:
+			return None
+		o = self.agent
+		if self.whom != None:
+			o += '/' + self.whom
+		return o
+
 class Message():
 
 	def __init__(self, **kwargs):
+		self.log = logging.getLogger(self.__class__.__name__)
+
 		self.body = kwargs.get('body', None)
 		self.type = kwargs.get('type', 'simple')
 		self.author = kwargs.get('author', None)
-		self.context = kwargs.get('context', Context())
+		self.origin = kwargs.get('origin', None)
 		self.misc = kwargs.get('misc', jsdict())
 
+		# Deprecated, remove at 1.0
+		# Supresses expected warning message
+		object.__setattr__(self, 'context', kwargs.get('context', Context()))
+		object.__setattr__(self.context, 'message', self)
+
+		if not 'origin' in kwargs:
+			object.__setattr__(self, 'origin', self.context.makeOrigin())
+		else:
+			# to setup the context properly
+			self.origin = self.origin
+
+	# Deprecated, remove at 1.0
+	def __setattr__(self, key, value):
+		if key == 'context':
+			self.log.warning('Deprecated use of "context" field on Message object')
+			value.message = self
+			object.__setattr__(self, 'origin', value.makeOrigin())
+
+		if key == 'origin' and value != None and 'context' in dir(self):
+			ls = value.split('/')
+			object.__setattr__(self.context, 'agent', ls[0])
+			object.__setattr__(self.context, 'whom', '/'.join(ls[1:]))
+
+		object.__setattr__(self, key, value)

--- a/halibot/message.py
+++ b/halibot/message.py
@@ -34,6 +34,7 @@ class Message():
 		self.author = kwargs.get('author', None)
 		self.origin = kwargs.get('origin', None)
 		self.misc = kwargs.get('misc', jsdict())
+		self.target = kwargs.get('target', '')
 
 		# Deprecated, remove at 1.0
 		# Supresses expected warning message
@@ -59,3 +60,6 @@ class Message():
 			object.__setattr__(self.context, 'whom', '/'.join(ls[1:]))
 
 		object.__setattr__(self, key, value)
+
+	def whom(self):
+		return '/'.join(self.target.split('/')[1:])

--- a/modules/modulecontainer/modulecontainer.py
+++ b/modules/modulecontainer/modulecontainer.py
@@ -2,8 +2,8 @@ from halibot import HalModule
 
 class ModuleContainer(HalModule):
 
-	def receive(self, msg, whom):
-		suff = '/' + whom if whom != '' else ''
+	def receive(self, msg):
+		suff = '/' + msg.whom() if msg.whom() != '' else ''
 		cont = self.config.get('contents', [])
 		self.send_to(msg, [ name + suff for name in cont ])
 

--- a/modules/modulecontainer/modulecontainer.py
+++ b/modules/modulecontainer/modulecontainer.py
@@ -2,6 +2,8 @@ from halibot import HalModule
 
 class ModuleContainer(HalModule):
 
-	def receive(self, msg):
-		self.send_to(msg, self.config.get('contents', []))
+	def receive(self, msg, whom):
+		suff = '/' + whom if whom != '' else ''
+		cont = self.config.get('contents', [])
+		self.send_to(msg, [ name + suff for name in cont ])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,9 +60,9 @@ class TestCore(util.HalibotTestCase):
 			timeout -= increment
 
 		self.assertEqual(3, len(mod.received))
-		self.assertEqual(foo, mod.received[0])
-		self.assertEqual(bar, mod.received[1])
-		self.assertEqual(baz, mod.received[2])
+		self.assertEqual(foo.body, mod.received[0].body)
+		self.assertEqual(bar.body, mod.received[1].body)
+		self.assertEqual(baz.body, mod.received[2].body)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
This deprecates the use of Contexts, which will be supported until 1.0.

See the first commit message for more details.
