### PR TITLE
Automatically set the origin on message objects.

### DIFF
--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -30,6 +30,10 @@ class HalObject():
 		pass
 
 	def send_to(self, msg, dests):
+		# Set origin for those who have not set it manually
+		if msg.origin == None:
+			msg.origin = self.name
+
 		for ri in dests:
 			name = ri.split('/')[0]
 			to = self._hal.get_object(name)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -45,7 +45,7 @@ class TestCore(util.HalibotTestCase):
 
 		foo = halibot.Message(body='foo')
 		bar = halibot.Message(body='bar')
-		baz = halibot.Message(body='baz')
+		baz = halibot.Message(body='baz', origin='glub_agent')
 
 		agent.connect(mod)
 		agent.dispatch(foo)
@@ -63,6 +63,12 @@ class TestCore(util.HalibotTestCase):
 		self.assertEqual(foo.body, mod.received[0].body)
 		self.assertEqual(bar.body, mod.received[1].body)
 		self.assertEqual(baz.body, mod.received[2].body)
+		self.assertEqual('stub_mod', mod.received[0].target)
+		self.assertEqual('stub_mod', mod.received[1].target)
+		self.assertEqual('stub_mod', mod.received[2].target)
+		self.assertEqual('stub_agent', mod.received[0].origin)
+		self.assertEqual('stub_agent', mod.received[1].origin)
+		self.assertEqual('glub_agent', mod.received[2].origin)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
See commits for details. The origin still needs to be manually set for objects that use the whom feature of resource identifiers for message origins.
