### PR TITLE
halibot: merge the agents and modules dict into one

### DIFF
--- a/halibot/halagent.py
+++ b/halibot/halagent.py
@@ -3,7 +3,7 @@ from .halobject import HalObject
 class HalAgent(HalObject):
 
 	def dispatch(self, msg):
-		out = self.config.get('out', self._hal.modules.keys())
+		out = self.config.get('out', self._hal.objects.modules.keys())
 		self.send_to(msg, out)
 
 	def connect(self, to):

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -137,9 +137,6 @@ class Halibot():
 
 			self.add_module_instance(k, obj(self, conf))
 
-	def get_object(self, name):
-		return self.objects.get(name, None)
-
 	def get_package(self, name):
 		for prefix in self.config['package-path']:
 			path = os.path.join(prefix, name, '__init__.py')
@@ -153,7 +150,7 @@ class Halibot():
 
 	# Restart a module instance by name
 	def restart(self, name):
-		o = self.get_object(name)
+		o = self.objects.get(name)
 		if o:
 			o.shutdown()
 			o.init()

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -36,7 +36,7 @@ class HalObject():
 
 		for ri in dests:
 			name = ri.split('/')[0]
-			to = self._hal.get_object(name)
+			to = self._hal.objects.get(name)
 			if to:
 				nmsg = copy.copy(msg)
 				nmsg.target = ri

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,7 @@ class TestAuth(util.HalibotTestCase):
 	def test_hasperm_func(self):
 		self.bot.auth.enabled = True
 		stub = StubModuleFunc(self.bot)
-		self.bot.add_module_instance('stub_mod', stub)
+		self.bot.add_instance('stub_mod', stub)
 
 		ri = "test/foobar"
 		user = "tester"
@@ -53,7 +53,7 @@ class TestAuth(util.HalibotTestCase):
 	def test_hasperm_dec(self):
 		self.bot.auth.enabled = True
 		stub = StubModuleDec(self.bot)
-		self.bot.add_module_instance('stub_mod', stub)
+		self.bot.add_instance('stub_mod', stub)
 
 		ri = "test/foobar"
 		user = "tester"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,14 +28,14 @@ class TestCore(util.HalibotTestCase):
 		self.bot.add_module_instance('stub_mod', stub)
 
 		self.assertTrue(stub.inited)
-		self.assertEqual(stub, self.bot.get_object('stub_mod'))
+		self.assertEqual(stub, self.bot.objects.get('stub_mod'))
 
 	def test_add_agent(self):
 		stub = StubAgent(self.bot)
 		self.bot.add_agent_instance('stub_agent', stub)
 
 		self.assertTrue(stub.inited)
-		self.assertEqual(stub, self.bot.get_object('stub_agent'))
+		self.assertEqual(stub, self.bot.objects.get('stub_agent'))
 
 	def test_send_recv(self):
 		agent = StubAgent(self.bot)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,14 +25,14 @@ class TestCore(util.HalibotTestCase):
 
 	def test_add_module(self):
 		stub = StubModule(self.bot)
-		self.bot.add_module_instance('stub_mod', stub)
+		self.bot.add_instance('stub_mod', stub)
 
 		self.assertTrue(stub.inited)
 		self.assertEqual(stub, self.bot.objects.get('stub_mod'))
 
 	def test_add_agent(self):
 		stub = StubAgent(self.bot)
-		self.bot.add_agent_instance('stub_agent', stub)
+		self.bot.add_instance('stub_agent', stub)
 
 		self.assertTrue(stub.inited)
 		self.assertEqual(stub, self.bot.objects.get('stub_agent'))
@@ -40,8 +40,8 @@ class TestCore(util.HalibotTestCase):
 	def test_send_recv(self):
 		agent = StubAgent(self.bot)
 		mod = StubModule(self.bot)
-		self.bot.add_agent_instance('stub_agent', agent)
-		self.bot.add_module_instance('stub_mod', mod)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_mod', mod)
 
 		foo = halibot.Message(body='foo')
 		bar = halibot.Message(body='bar')


### PR DESCRIPTION
For a long time, it has been debated if the agents and modules
dictionaries really needed to be separate. Both contain HalObjects with
similar interfaces, so they are not so different. However, with the
introduction of RIs, the leading argument against merging them has been
eliminated: agent and module instances can no longer share the same
name.

Since an agent and module can't have the same name, there is effectively
no longer a point to separating them. They have been replaced by a small
dictionary class that provides read-only attributes that handle the
filtering for you: .agents and .modules for geting just agents and
modules respectively.

This simplifies the lookup and addition of new objects, as there is no
longer two separate dictionaries that need to be examined.
