### PR TITLE
RFC: Use coroutines + futures to detect module receive completion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install coveralls
 script: ./test.sh

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -21,7 +21,8 @@ class HalObject():
 		self.shutdown()
 
 	def _queue_msg(self, msg):
-		self.eventloop.call_soon_threadsafe(self.receive, msg)
+		fut = asyncio.run_coroutine_threadsafe(self._receive(msg), self.eventloop)
+		return fut
 
 	def init(self):
 		pass
@@ -40,9 +41,13 @@ class HalObject():
 			if to:
 				nmsg = copy.copy(msg)
 				nmsg.target = ri
-				to._queue_msg(nmsg)
+				return to._queue_msg(nmsg)
 			else:
 				self.log.warning('Unknown module/agent: ' + str(name))
+
+	async def _receive(self, msg):
+		self.receive(msg)
+
 
 	def receive(self, msg):
 		pass


### PR DESCRIPTION
**THIS IS VERY RFC DON'T MERGE**

Before, it was impossible to detect when a sent message was done being handled
by a particular module. This small change queues the message as a coroutine,
which can be awaited on (or not!).

While this commit itself isn't very exciting, there is a bunch of potential hidden in this. This means that a module can make a message pass to another module and wait for the response before continuing on.

What I haven't figured out yet is how we can actually return something of value here... My unfortunate current running theory is hijacking the `.reply()` message to be an *actual* call, and not just a convenience function. Instead, `.reply()` would add messages to a queue that would be returned with the future/coroutine (somehow).

This does mean though that things like `!quote` and so on strictly become "responsive replies", rather than generating a new message to pass along. On the other hand, I'm not sure we really need this anyway. I don't see why the agent can't just handle the reply by passing it to its own `.receive()`.