### PR TITLE
Configurer class implementation

### DIFF
--- a/doc/ConfigureOptions.md
+++ b/doc/ConfigureOptions.md
@@ -20,7 +20,7 @@ The `HalConfigurer` class provides a method called `option` which prompts the
 user to configure an option. For syntax is as follows:
 
 ```python
-HalConfigurer.option(option_type, key=, prompt=, default=)
+HalConfigurer.option(option_type, key, prompt=, default=)
 ```
 
 * `option_type` is an instance of a subclass of `Halibot.Option` that determines
@@ -46,17 +46,14 @@ These option types are further made easily available via wrapper functions that
 simply wrap to the underlying `HalConfigurer.option`, and are respectively as
 follows:
 
-* `HalConfigurer.optionString(key=, prompt=, default=)`
-* `HalConfigurer.optionInt(key=, prompt=, default=)`
-* `HalConfigurer.optionNumber(key=, prompt=, default=)`
-* `HalConfigurer.optionBool(key=, prompt=, default=)`
+* `HalConfigurer.optionString(key, prompt=, default=)`
+* `HalConfigurer.optionInt(key, prompt=, default=)`
+* `HalConfigurer.optionNumber(key, prompt=, default=)`
+* `HalConfigurer.optionBool(key, prompt=, default=)`
 
-The `HalConfigurer` class also has a `validate` function, which consumes the
+The `HalConfigurer` class also has a `valid` function, which consumes the
 user-defined configure function automatically and returns True or False
-depending on whether or not the currently specified config is valid. The
-validate function takes the optional parameter of `config` which will set the
-config to check, where otherwise it checks the config already associated with
-the configurer.
+depending on whether or not the currently given value is valid.
 
 Example module with Configurer
 ------------------------------
@@ -69,9 +66,9 @@ class Responder(HalModule):
 
 	class Configurer(HalConfigurer):
 		def configure(self):
-			self.optionString(key='accept', prompt='Accept string')
-			self.optionString(key='return', prompt='Return string')
-			self.optionInt(key='delay', prompt='Wait seconds before responding', default=0)
+			self.optionString('accept', prompt='Accept string')
+			self.optionString('return', prompt='Return string')
+			self.optionInt('delay', prompt='Wait seconds before responding', default=0)
 
 	def message(self, msg):
 		if 'accept' in self.config and msg.body == self.config['accept']:
@@ -85,17 +82,13 @@ The Option class
 The `Option` class allows you to write your own prompting or validation
 mechanisms for a specific object type.
 
-There are four methods one should define:
+There are methods one can override are:
 
-* `configure(self, prompt)` which prompts the user for the value for this option
-  type with the given prompt. Sets a `self.value` to the result of the prompt by
-  default, calls `self.validate` to check, and reprompts if the validation failed.
-* `validate(self)` which returns true if the option's value is valid. Always
+* `ask(self)` which prompts the user for a configuration value and returns it
+* `configure(self)` which by default wraps to `ask` and checks that the
+  response given is valid.
+* `valid(self, value)` which returns true if the option's value is valid. Always
   returns true by default.
-* `get(self)` which retrieves the JSON-compliant value set for this option.
-  Returns `self.value` by default.
-* `set(self, value)` which sets a value for this option from the JSON-compliant
-  value. Simply sets `self.value` by default.
 
 Example custom Option class
 ---------------------------
@@ -115,7 +108,7 @@ import os
 from tkinter.filedialog import askopenfilename
 
 class OptFile(halibot.Option.String):
-	def prompt(self):
+	def ask(self):
 		self.value = askopenfilename()
 
 	def validate(self):

--- a/halibot/__init__.py
+++ b/halibot/__init__.py
@@ -1,4 +1,5 @@
 from .halibot import Halibot
 from .halagent import HalAgent
 from .halmodule import HalModule
+from .halconfigurer import HalConfigurer
 from .message import Context, Message

--- a/halibot/halconfigurer.py
+++ b/halibot/halconfigurer.py
@@ -1,0 +1,82 @@
+
+class Option():
+	def __init__(self, key, prompt=None, default=None):
+		self.key = key
+		self.prompt = prompt if prompt != None else key
+		self.default = default
+
+	def ask(self):
+		prompt = self.prompt
+		if self.default != None:
+			prompt += ' [' + str(self.default) + ']'
+		prompt += ': '
+
+		v = input(prompt)
+		if v == '': return self.default
+		return v
+
+	def configure(self):
+		while True:
+			try:
+				v = self.ask()
+			except ValueError:
+				continue
+			if self.valid():
+				break
+		return v
+
+	def valid(self):
+		return True
+
+# Builtin option classes
+class StringOption(Option):
+	pass
+
+class IntOption(Option):
+	def ask(self):
+		return int(super().ask())
+
+class NumberOption(Option):
+	def ask(self):
+		return float(super().ask())
+
+class BooleanOption(Option):
+	def ask(self):
+		v = super().ask()
+		if isinstance(v, str):
+			if v.lower() == 'true':  return True
+			if v.lower() == 'false': return False
+			raise ValueError()
+		return v
+
+Option.String = StringOption
+Option.Int = IntOption
+Option.Number = NumberOption
+Option.Boolean = BooleanOption
+
+class HalConfigurer():
+
+	def __init__(self):
+		self.options = {}
+
+	def option(self, option_type, key, **kwargs):
+		opt = option_type(key, **kwargs)
+		val = opt.configure()
+		if val != None:
+			self.options[key] = val
+
+	def optionString(self, key, **kwargs):
+		self.option(Option.String, key, **kwargs)
+
+	def optionInt(self, key, **kwargs):
+		self.option(Option.Int, key, **kwargs)
+
+	def optionNumber(self, key, **kwargs):
+		self.option(Option.Number, key, **kwargs)
+
+	def optionBoolean(self, key, **kwargs):
+		self.option(Option.Boolean, key, **kwargs)
+
+	def configure(self):
+		pass
+

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -3,6 +3,7 @@ import asyncio
 import inspect
 import copy
 from threading import Thread
+from .halconfigurer import HalConfigurer
 
 class HalObject():
 
@@ -47,36 +48,19 @@ class HalObject():
 	def receive(self, msg):
 		pass
 
+
+	class Configurer(HalConfigurer):
+		pass
+
 	# Configures an instance of this class based on the 'options' attribute
 	@classmethod
 	def configure(cls, conf):
 		name = input('Enter instance name: ')
 
-		for key in getattr(cls, 'options', {}):
-			opt = cls.options[key]
+		configurer = cls.Configurer()
+		configurer.configure()
 
-			prompt = opt['prompt']
-			if 'default' in opt:
-				prompt += ' [' + str(opt['default']) + ']: '
-			else:
-				prompt += ': '
-
-			val = input(prompt)
-			if val == '':
-				if 'default' in opt:
-					val = opt['default']
-				else:
-					# Don't write this key
-					continue
-
-			if opt['type'] == 'int':
-				conf[key] = int(val)
-			elif opt['type'] == 'float':
-				conf[key] = float(val)
-			elif opt['type'] == 'bool':
-				conf[key] = (val.lower() == 'true')
-			else:
-				conf[key] = val
+		conf = {**conf, **configurer.options}
 
 		return name, conf
 

--- a/packages/irc/irc.py
+++ b/packages/irc/irc.py
@@ -2,7 +2,7 @@
 # Reference Halibot IRC Agent
 #  Connects to an IRC server and relays messages to and from the base
 #
-from halibot import HalAgent, Context, Message
+from halibot import HalAgent, HalConfigurer, Context, Message
 from collections import OrderedDict
 import pydle, threading
 
@@ -12,61 +12,20 @@ import pydle, threading
 #  Receives messages from the Halibot base, relays them to the IRC server
 class IrcAgent(HalAgent):
 
-	options = OrderedDict([
-		('nickname', {
-			'type'    : 'string',
-			'prompt'  : 'Nickname',
-			'default' : 'halibot',
-		}),
-		('hostname', {
-			'type'    : 'string',
-			'prompt'  : 'Server hostname',
-			'default' : 'irc.freenode.net',
-		}),
-		('port', {
-			'type'    : 'string',
-			'prompt'  : 'Server port',
-			'default' : '6697',
-		}),
-		('channel', {
-			'type'    : 'string',
-			'prompt'  : 'Channel to join',
-		}),
-		('tls', {
-			'type'    : 'bool',
-			'prompt'  : 'Enable TLS',
-			'default' : 'true',
-		}),
-		('tls-verify', {
-			'type'    : 'bool',
-			'prompt'  : 'Verify server TLS certificate',
-			'default' : 'false',
-		}),
-		('tls-certificate-file', {
-			'type'    : 'string',
-			'prompt'  : 'TLS certificate file',
-		}),
-		('tls-certificate-keyfile', {
-			'type'    : 'string',
-			'prompt'  : 'TLS certificate keyfile',
-		}),
-		('tls-certificate-password', {
-			'type'    : 'string',
-			'prompt'  : 'TLS certificate password',
-		}),
-		('sasl-username', {
-			'type'    : 'string',
-			'prompt'  : 'SASL username',
-		}),
-		('sasl-password', {
-			'type'    : 'string',
-			'prompt'  : 'SASL password',
-		}),
-		('sasl-identity', {
-			'type'    : 'string',
-			'prompt'  : 'SASL identity',
-		}),
-	])
+	class Configurer(HalConfigurer):
+		def configure(self):
+			self.optionString('nickname', prompt='Nickname', default='halibot')
+			self.optionString('hostname', prompt='Server hostname', default='irc.freenode.net')
+			self.optionInt('port', prompt='Server port', default=6697)
+			self.optionString('channel', prompt='Channel to join')
+			self.optionBoolean('tls', prompt='Enable TLS', default=True)
+			self.optionBoolean('tls-verify', prompt='Verify server TLS certificate', default=False)
+			self.optionString('tls-certificate-file', prompt='TLS certificate file')
+			self.optionString('tls-certificate-keyfile', prompt='TLS certificate keyfile')
+			self.optionString('tls-certificate-file', prompt='TLS certificate password')
+			self.optionString('sasl-username', prompt='SASL username')
+			self.optionString('sasl-password', prompt='SASL password')
+			self.optionString('sasl-identity', prompt='SASL identity')
 
 	# Handle to the Pydle IRC Client object as defined below
 	client = None


### PR DESCRIPTION
Implementation of the HalConfigurer class as specified in #70, with the following modifications:
 * removal of get/set functions
 * validate() renamed to valid()
 * key made a positional parameter
 * addition of ask function which prompts for input once and does not call valid(), the configure() function instead provides an ask-then-validate loop
 * ask/configure return values rather than set an internal value