### PR TITLE
Add 'config' command option

### DIFF
--- a/halibot/halconfigurer.py
+++ b/halibot/halconfigurer.py
@@ -56,11 +56,16 @@ Option.Boolean = BooleanOption
 
 class HalConfigurer():
 
-	def __init__(self):
-		self.options = {}
+	def __init__(self, options={}):
+		self.options = options
 
 	def option(self, option_type, key, **kwargs):
 		opt = option_type(key, **kwargs)
+
+		# Override the default if the option is already set
+		if key in self.options:
+			opt.default = self.options[key]
+
 		val = opt.configure()
 		if val != None:
 			self.options[key] = val

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -82,15 +82,14 @@ class HalObject():
 
 	# Configures an instance of this class based on the 'options' attribute
 	@classmethod
-	def configure(cls, conf):
-		name = input('Enter instance name: ')
+	def configure(cls, conf, name=None):
+		if name == None:
+			name = input('Enter instance name: ')
 
-		configurer = cls.Configurer()
+		configurer = cls.Configurer(options=conf)
 		configurer.configure()
 
-		conf = {**conf, **configurer.options}
-
-		return name, conf
+		return name, configurer.options
 
 	def invoke(self, inst, method, *args, **kwargs):
 		return getattr(self._hal.objects[inst], method)(*args, **kwargs)

--- a/main.py
+++ b/main.py
@@ -280,20 +280,13 @@ def h_config(args):
 	bot = halibot.Halibot()
 	bot._load_config()
 
-	# Do we have a module or an agent?
-	if args.destkey:
-		destkey = args.destkey
+	if args.name in bot.config["agent-instances"]:
+		destkey = "agent-instances"
+	elif args.name in bot.config["module-instances"]:
+		destkey = "module-instances"
 	else:
-		is_agent  = args.name in bot.config["agent-instances"]
-		is_module = args.name in bot.config["module-instances"]
-		if is_agent == is_module:
-			if is_agent:
-				print("Both an agent and module exist with that name. -a or -m must be specified.")
-			else:
-				print("No such agent or module exists.")
-			return
-		else:
-			destkey = "agent-instances" if is_agent else "module-instances"
+		print('No such module or agent exists.')
+		return
 	pkgconf = bot.config[destkey][args.name]
 
 	# Show or edit the config?
@@ -416,8 +409,6 @@ if __name__ == "__main__":
 	config_cmd.add_argument("-s", "--show", action="store_true", help="show the configuration rather than set it", required=False)
 	config_cmd.add_argument("-k", "--key", help="key to set or key to display with -s", required=False)
 	config_cmd.add_argument("-v", "--value", help="value to set key to", required=False)
-	config_cmd.add_argument("-a", "--agent", dest="destkey", action="store_const", const="agent-instances", help="configure the instance as an agent. Only requried when an agent and a module share a name")
-	config_cmd.add_argument("-m", "--module", dest="destkey", action="store_const", const="module-instances", help="configure instance as a module. Only required when an agent and a module share a name")
 	config_cmd.add_argument("-t", "--type", choices=["string", "number", "boolean"], help="the type used while setting a config value with -k. If not given, it uses the type of the existing value")
 
 	args = parser.parse_args()


### PR DESCRIPTION
Couple changes to the internal config stuff was done to allow defaulting to the existing values when reconfiguring.

With regard to the usage of this command, just an instance name alone reruns the configure prompts, with the default values being the current value in the config. `-s/--show` allows will instead show you the current config. `-s/--show` can be used with `-k/--key` to only show a specific field.

`-k/--key` and `-v/--value` can be used to set a single key value pair; the type of which is determined from the existing key, but can be set explicitly with the `-t/--type` option.

~~`-a/--agent` and `-m/--module` are necessary when an agent and a module share a key (which seems like bad practice though) to differentiate between the two.~~ These options were removed as they should never be necessary in a sane configuration.