### PR TITLE
halobject: close the eventloop after it is stopped

### DIFF
--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -18,8 +18,12 @@ class HalObject():
 		self.sync_replies = defaultdict(lambda: []) # UUID -> [Message, ...]
 
 		self.eventloop = asyncio.SelectorEventLoop()
-		self._thread = Thread(target=self.eventloop.run_forever)
+		self._thread = Thread(target=self._run_eventloop)
 		self._thread.start()
+
+	def _run_eventloop(self):
+		self.eventloop.run_forever()
+		self.eventloop.close()
 
 	def _shutdown(self):
 		self.eventloop.call_soon_threadsafe(self.eventloop.stop)


### PR DESCRIPTION
This suppresses a nondeterministic exception thrown from the tests when
the bot shuts down too quickly. Probably exists with regular closing
too.

This PR is mostly to see if it magically fixes our non-deterministic travis builds