### PR TITLE
halibot: add version checks on loaded objects to ensure compatibility

### DIFF
--- a/halibot/__init__.py
+++ b/halibot/__init__.py
@@ -1,4 +1,4 @@
-from .halibot import Halibot
+from .halibot import Halibot, Version
 from .halagent import HalAgent
 from .halmodule import HalModule
 from .halobject import HalObject, SyncSendSelfException

--- a/packages/hello/hello.py
+++ b/packages/hello/hello.py
@@ -10,6 +10,16 @@ from halibot import HalModule, Message
 #  If so, responds with "Hello World!" via the same way the message was received
 class Hello(HalModule):
 
+	# Module version strings
+	#  These should be defined so that Halibot can safety-check modules prior to
+	#  loading that may use unimplemented or deprecated features
+	#  VERSION - what is the version of this module (for reference), using semver.
+	#  HAL_MINIMUM - minimum version of Halibot core that this module will work with
+	#  HAL_MAXIMUM - (optional) reject Halibot core versions newer than this.
+
+	VERSION = "1.0.0"
+	HAL_MINIMUM = "0.1"
+
 	# Called when the module is initialized
 	#  Put any initialization logic here, instead of __init__()
 	#  In this case, no initialization is needed, thus it is a no-op

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,5 +184,64 @@ class TestCore(util.HalibotTestCase):
 		self.assertEqual(agent.sync_send_to(msgt1, ['stub_module'])['stub_module'][0].body, topic1_text)
 		self.assertEqual(agent.sync_send_to(msgt2, ['stub_module'])['stub_module'][0].body, topic2_text)
 
+	def test_version_class(self):
+		# Test major comparison
+		self.assertTrue(halibot.Version("1.0.0") >= halibot.Version("0.1.0"))
+		self.assertTrue(halibot.Version("0.1.0") <= halibot.Version("1.0.0"))
+		self.assertTrue(halibot.Version("1.0.0") > halibot.Version("0.1.0"))
+		self.assertTrue(halibot.Version("0.1.0") < halibot.Version("1.0.0"))
+
+		# Test minor comparison
+		self.assertTrue(halibot.Version("1.1.0") >= halibot.Version("1.0.0"))
+		self.assertTrue(halibot.Version("1.0.0") <= halibot.Version("1.1.0"))
+		self.assertTrue(halibot.Version("1.1.0") > halibot.Version("1.0.0"))
+		self.assertTrue(halibot.Version("1.0.0") < halibot.Version("1.1.0"))
+
+		# Test negatives of above
+		self.assertFalse(halibot.Version("1.0.0") <= halibot.Version("0.1.0"))
+		self.assertFalse(halibot.Version("0.1.0") >= halibot.Version("1.0.0"))
+		self.assertFalse(halibot.Version("1.0.0") < halibot.Version("0.1.0"))
+		self.assertFalse(halibot.Version("0.1.0") > halibot.Version("1.0.0"))
+
+		self.assertFalse(halibot.Version("1.1.0") <= halibot.Version("1.0.0"))
+		self.assertFalse(halibot.Version("1.0.0") >= halibot.Version("1.1.0"))
+		self.assertFalse(halibot.Version("1.1.0") < halibot.Version("1.0.0"))
+		self.assertFalse(halibot.Version("1.0.0") > halibot.Version("1.1.0"))
+
+		# Test equalities
+		self.assertEqual(halibot.Version("1.0.0"), halibot.Version("1.0.0"))
+		self.assertNotEqual(halibot.Version("1.0.0"), halibot.Version("1.0.1"))
+		self.assertNotEqual(halibot.Version("1.0.0"), halibot.Version("1.1.1"))
+		self.assertNotEqual(halibot.Version("1.0.0"), halibot.Version("0.0.0"))
+
+	def test_version_check(self):
+		class VersionOkModule(halibot.HalModule):
+			HAL_MINIMUM = "0.0.1"
+			HAL_MAXIMUM = "1.0.0"
+
+		class VersionFailMinModule(halibot.HalModule):
+			HAL_MINIMUM = "1.0.0"
+			HAL_MAXIMUM = "1.0.0"
+
+		class VersionFailMaxModule(halibot.HalModule):
+			HAL_MINIMUM = "0.0.1"
+			HAL_MAXIMUM = "0.0.1"
+
+		mod0 = VersionOkModule(self.bot) # Load ok
+		mod1 = VersionFailMinModule(self.bot) # Fail minimum
+		mod2 = VersionFailMaxModule(self.bot) # Fail maximum
+
+		self.bot.VERSION = "0.1.0"
+
+		self.assertTrue(self.bot._check_version(mod0))
+		self.assertFalse(self.bot._check_version(mod1))
+		self.assertFalse(self.bot._check_version(mod2))
+
+		# Add the instances so they get cleaned up properly...
+		self.bot.add_instance("mod0", mod0)
+		self.bot.add_instance("mod1", mod1)
+		self.bot.add_instance("mod2", mod2)
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
**NOTE:** This is *very* RFC, please do not merge yet!

Currently, Halibot objects (modules/agents) are always loaded, and it is up to the runtime to determine whether or not they are compatible with the current core. This PR implements a system that defines a system for comparing versions on attempt to load an object from a package. This implements issue #83 .

All Hal objects should define the following class-level fields:
 - `VERSION` - a string denoting the version of the module. This is mostly for reference, potentially for allowing loading of alternate versions in the future
 - `HAL_MINIMUM` - a string denoting the minimum compatible version of Halibot core this object can work with.
 - `HAL_MAXIMUM` - (optional) the last version of Halibot core that this object still works with. This is optional, core will accept the module if omitted (so long as the minimum check passes).

Things to consider:
 - List of specific versions to reject? If for example some version introduces a bug, maybe that patch level should be blacklisted
 - Should `HAL_MAXIMUM` be required? This could probably blanket catch deprecations faster than module devs (or if a module is abandoned), though also could be annoying. Maybe a config option?
 - Currently I have patch level as optional in version tags, defaulting to 0. Not sure if there's actually value in this, but default to 0 assumes "all of `1.0.x` is valid". Probably should require all three for consistency.
 - Should the version tags be tucked away in a `meta` subclass? There could be value in this, but I wanted to keep the overhead for developers small
 - Same goes for the `Version()` class. Version tags are stored as strings, but we could use the version object on the class rather than constructing the class only for a check. Maybe with some setattr magic again we can automatically construct it from a string assigment?

There's a lot of questions on this feature, so I'd like this to sit through some rounds of feedback first before merging.