### PR TITLE
Add Help core module

### DIFF
--- a/packages/hello/hello.py
+++ b/packages/hello/hello.py
@@ -30,3 +30,10 @@ class Hello(HalModule):
 	# NOTE: The HalModule also includes a send() method, which reply() calls out to
 	#  reply() is the same as send()'ing a copy of the received message, with a new body
 	#  Do NOT override send() or reply(), they are already implemented for you.
+
+	# Define help text for our module. This will be called by a Help module if loaded.
+	#  See doc/HelpInterface.md for more details
+	def help(self, args=""):
+		if args == "!hello":
+			return "Displays a wonderful greeting! :D"
+		return "A delightful greeting module! Available command(s): !hello"

--- a/packages/help/__init__.py
+++ b/packages/help/__init__.py
@@ -1,0 +1,2 @@
+from .help import Help
+Default = Help

--- a/packages/help/help.py
+++ b/packages/help/help.py
@@ -1,0 +1,41 @@
+from halibot import HalModule
+
+class Help(HalModule):
+
+	def init(self):
+		self.commands = {
+			"help": self.help_
+		}
+
+	def receive(self, msg):
+		if not msg.body or not msg.body.startswith("!"):
+			return
+		body = msg.body.split(" ")
+		func = self.commands.get(body[0][1:])
+		if func:
+			func(body[1:], msg=msg)
+
+	def help_(self, ls, msg=None):
+		if not ls:
+			resp = self.help()
+		elif ls[0] not in [o[0] for o in self._hal.objects.items() if hasattr(o[1], "help")]:
+			self.reply(msg, body="Topic '{}' not found!".format(ls[0]))
+			return
+		else:
+			resp = self.invoke(ls[0], "help", args=" ".join(ls[1:]))
+
+		# TODO: Let the agent handle this
+		for r in resp.split("\n"):
+			self.reply(msg, body=r)
+
+	def help(self, args=""):
+		if args == "!help":
+			return ":)"
+		# Allow admins to configure the greeting on the bot
+		ret = self.config.get("banner", "Your friendly saltwater bot!")
+		ret += " Use !help <topic> to get specific module help\n"
+		# TODO: This should probably limit itself when there are too many objects
+		# TODO: This should also be container-aware, so it should only report objects accessible from sender's RI
+		# Only show modules that define a `.help()` method
+		ret += "Loaded topics: " + ", ".join([o[0] for o in self._hal.objects.items() if hasattr(o[1], "help")])
+		return ret


### PR DESCRIPTION
This commit implements the interface for defining help text as described in doc/HelpInterface.md and in issue #51 . The test module "Hello" has also been updated to use the new `.help()` method as an example.

There are a few "TODO" items, but I think we can overlook them for now to get this system moving.

The module is also written in such a way that it can be converted to (and thus be the posterchild for) a `CommandModule` if that ever sees the light of day.