### PR TITLE
Implement help module

### DIFF
--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -86,6 +86,17 @@ class HalObject():
 	def receive(self, msg):
 		pass
 
+	def receive_help(self, msg):
+		prefix = 'help_'
+		if msg.body == []:
+			# Retrieve available topics
+			topics = [a[len(prefix):] for a in dir(self) if a.startswith(prefix)]
+			self.reply(msg, body=topics)
+		else:
+			# Retrieve help text for topic
+			fname = prefix + '_'.join(msg.body)
+			if hasattr(self, fname) and callable(getattr(self, fname)):
+				self.reply(msg, body=getattr(self, fname)())
 
 	class Configurer(HalConfigurer):
 		pass

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -73,7 +73,13 @@ class HalObject():
 
 	async def _receive(self, msg):
 		try:
-			self.receive(msg)
+			fname = 'receive_' + msg.type
+			if hasattr(self, fname) and callable(getattr(self, fname)):
+				# Type specific receive function
+				getattr(self, fname)(msg)
+			else:
+				# Generic receive function
+				self.receive(msg)
 		except Exception as e:
 			traceback.print_exc()
 

--- a/packages/core/__init__.py
+++ b/packages/core/__init__.py
@@ -1,0 +1,2 @@
+
+from .help import Help

--- a/packages/core/help.py
+++ b/packages/core/help.py
@@ -1,0 +1,71 @@
+#
+# HelpModule
+#
+from halibot import CommandModule, Message
+
+class Help(CommandModule):
+
+	def init(self):
+		self.commands = {
+			'help' : self.command
+		}
+
+	def general_help(self, target):
+		hmsg = Message(body=[], type='help', origin=self.name)
+		replies = self.sync_send_to(hmsg, target)
+
+		text = '''The help command gives useful help messages.
+
+Syntax:
+  !help <topic> [<subtopic> ...]
+
+Available topics:
+'''
+		# Collect the available topics
+		topics = []
+		for r in replies.values():
+			topics += [t for t in r[0].body if not t in topics]
+
+		# Append the available topics to the list
+		c = 2
+		line = '  '
+		max_column = 80
+		first = True
+		for t in topics:
+			if c + len(t) + 2 > max_column:
+				text += line + '\n'
+				c = 2
+				line = '  '
+				first = True
+
+			if first:
+				first = False
+			else:
+				line += ', '
+				c += 2
+
+			line += t
+			c += len(t)
+
+		# Append final line
+		if line.strip() != '':
+			text += line + '\n'
+
+		return text
+
+	def command(self, args, msg=None):
+		# TODO When containers/routes become more integrated, just look at the
+		#      container the message was sent to, which shoudl work for the
+		#      default container as well.
+		target = self.config.get('target', self._hal.objects.modules.keys())
+		target = [t for t in target if t.split('/')[0] != self.name] # Can't sync send to this module
+
+		if args == '':
+			self.reply(msg, body=self.general_help(target))
+		else:
+			hmsg = Message(body=args.split(' '), type='help', origin=self.name)
+			replies = self.sync_send_to(hmsg, target)
+
+			if len(replies) > 0:
+				# TODO check for discrepancies among replies
+				self.reply(msg, body=list(replies.values())[0][0].body)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,15 +5,28 @@ import util
 import halibot
 import unittest
 
+topic1_text = 'Help text one'
+topic2_text = 'Help text two'
+
 class StubModule(halibot.HalModule):
 	inited = False
 
 	def init(self):
 		self.inited = True
 		self.received = []
+		self.received_mytype = []
 
 	def receive(self, msg):
 		self.received.append(msg)
+
+	def receive_mytype(self, msg):
+		self.received_mytype.append(msg)
+
+	def help_topic1(self):
+		return topic1_text
+
+	def help_topic2(self):
+		return topic2_text
 
 class StubReplier(halibot.HalModule):
 	inited = False
@@ -71,6 +84,7 @@ class TestCore(util.HalibotTestCase):
 		bar = halibot.Message(body='bar')
 		baz = halibot.Message(body='baz', origin='glub_agent')
 		qua = halibot.Message(body='qua')
+		qua2 = halibot.Message(body='qua', type='mytype')
 
 		agent.dispatch(foo) # 0
 		agent.send_to(bar, [ 'stub_mod/able', 'stub_mod2/baker' ] ) # 1
@@ -78,6 +92,8 @@ class TestCore(util.HalibotTestCase):
 		agent.dispatch(baz) # 2
 		agent.connect(mod2)
 		agent.dispatch(qua) # 3
+
+		agent.dispatch(qua2) # 3
 
 		util.waitOrTimeout(100, lambda: len(mod.received) == 4 and len(mod2.received) == 3)
 
@@ -115,6 +131,13 @@ class TestCore(util.HalibotTestCase):
 		self.assertEqual('stub_agent', mod2.received[1].origin)
 		self.assertEqual('stub_agent', mod2.received[2].origin)
 
+		# Check mytype messages
+		self.assertEqual(1, len(mod.received_mytype))
+		self.assertEqual(1, len(mod2.received_mytype))
+		self.assertEqual(qua2.body, mod.received_mytype[0].body)
+		self.assertEqual(qua2.body, mod2.received_mytype[0].body)
+
+
 	def test_send_reply(self):
 		agent = StubAgent(self.bot)
 		mod = StubReplier(self.bot)
@@ -144,6 +167,22 @@ class TestCore(util.HalibotTestCase):
 		rep = agent.sync_send_to(foo, ['stub_module'])
 
 		self.assertEqual(rep["stub_module"][0].body, "foobar")
+
+	def test_help(self):
+		agent = StubAgent(self.bot)
+		mod = StubModule(self.bot)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_module', mod)
+
+		msgt0 = halibot.Message(type='help', body=[])
+		msgt1 = halibot.Message(type='help', body=['topic1'])
+		msgt2 = halibot.Message(type='help', body=['topic2'])
+
+		self.assertEqual(agent.sync_send_to(msgt0, ['stub_module'])['stub_module'][0].body, ['topic1', 'topic2'])
+		self.assertEqual(agent.sync_send_to(msgt1, ['stub_module'])['stub_module'][0].body, topic1_text)
+		self.assertEqual(agent.sync_send_to(msgt2, ['stub_module'])['stub_module'][0].body, topic2_text)
+
+		
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
An alternative to #86. When the help module receives a command for a topic (not the top-level), it sends a message to the other modules to look for that topic, and replies with the associated help text. Right now a container needs to be specified explicitly, ideally when the container/routing revisions discussed in the October 3rd meeting are implemented in some fashion or another there will not be a need for the `target` configuration option.

There is a built-in top-level help text, which also queries all the other modules for the available topics and reports them.