### PR TITLE
Use dict for topics, not help_ method prefix

### DIFF
--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -87,16 +87,16 @@ class HalObject():
 		pass
 
 	def receive_help(self, msg):
-		prefix = 'help_'
-		if msg.body == []:
-			# Retrieve available topics
-			topics = [a[len(prefix):] for a in dir(self) if a.startswith(prefix)]
-			self.reply(msg, body=topics)
-		else:
-			# Retrieve help text for topic
-			fname = prefix + '_'.join(msg.body)
-			if hasattr(self, fname) and callable(getattr(self, fname)):
-				self.reply(msg, body=getattr(self, fname)())
+		if hasattr(self, 'topics'):
+			if msg.body == []:
+				# Retrieve available topics
+				self.reply(msg, body=list(self.topics.keys()))
+			else:
+				# Retrieve help text for topic
+				key = '/'.join(msg.body)
+				if key in self.topics:
+					t = self.topics[key]
+					self.reply(msg, body=t() if callable(t) else t)
 
 	class Configurer(HalConfigurer):
 		pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,11 @@ topic2_text = 'Help text two'
 class StubModule(halibot.HalModule):
 	inited = False
 
+	topics = {
+		'topic1': lambda: topic1_text,
+		'topic2': topic2_text
+	}
+
 	def init(self):
 		self.inited = True
 		self.received = []
@@ -21,12 +26,6 @@ class StubModule(halibot.HalModule):
 
 	def receive_mytype(self, msg):
 		self.received_mytype.append(msg)
-
-	def help_topic1(self):
-		return topic1_text
-
-	def help_topic2(self):
-		return topic2_text
 
 class StubReplier(halibot.HalModule):
 	inited = False
@@ -178,11 +177,9 @@ class TestCore(util.HalibotTestCase):
 		msgt1 = halibot.Message(type='help', body=['topic1'])
 		msgt2 = halibot.Message(type='help', body=['topic2'])
 
-		self.assertEqual(agent.sync_send_to(msgt0, ['stub_module'])['stub_module'][0].body, ['topic1', 'topic2'])
+		self.assertEqual(set(agent.sync_send_to(msgt0, ['stub_module'])['stub_module'][0].body), set(['topic1', 'topic2']))
 		self.assertEqual(agent.sync_send_to(msgt1, ['stub_module'])['stub_module'][0].body, topic1_text)
 		self.assertEqual(agent.sync_send_to(msgt2, ['stub_module'])['stub_module'][0].body, topic2_text)
-
-		
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
This should simplify the implementation of help text from a module-developer standpoint, as then need only define a dictionary of the form topic -> {help text|function returning help text}.

Example:
```python
topics = {
  'topic1': 'Topic one text',
  'topic2': lambda: 'Topic two text'
}
```