### PR TITLE
halmodule: fix false origin on replies

### DIFF
--- a/halibot/halmodule.py
+++ b/halibot/halmodule.py
@@ -8,7 +8,7 @@ class HalModule(HalObject):
 		body = kwargs.get('body', msg0.body)
 		mtype = kwargs.get('type', msg0.type)
 		author = kwargs.get('author', msg0.author)
-		origin = kwargs.get('origin', msg0.origin)
+		origin = kwargs.get('origin', self.name)
 
 		msg = Message(body=body, type=mtype, author=author, origin=origin)
 
@@ -16,7 +16,7 @@ class HalModule(HalObject):
 		if msg0.sync:
 			self.sync_replies[msg0.uuid].append(msg)
 		else:
-			self.send_to(msg, [ msg.origin ])
+			self.send_to(msg, [ msg0.origin ])
 
 	def hasPermission(self, msg, perm):
 		return self._hal.auth.hasPermission(msg.origin, msg.identity, perm)


### PR DESCRIPTION
Origin should be set to wherever a message comes from -- this includes
modules. Therefore, we should not be setting the origin to where the message
we are replying to is from.

e.g. replying to a message from "irc/##foobar" should not reply with the
origin "irc/##foobar" as well. This could cause problems with replying
to replies.