### PR TITLE
Add a config writing method to Halibot core

### DIFF
--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -40,6 +40,7 @@ class Halibot():
 
 		self.use_config = kwargs.get("use_config", True)
 		self.use_auth = kwargs.get("use_auth", True)
+		self.workdir = kwargs.get("workdir", ".")
 
 		self.auth = HalAuth()
 		self.objects = ObjectDict()
@@ -70,12 +71,12 @@ class Halibot():
 		self.log.info("Instantiated object '" + name + "'")
 
 	def _load_config(self):
-		with open("config.json","r") as f:
+		with open(os.path.join(self.workdir, "config.json"), "r") as f:
 			self.config = json.loads(f.read())
 			halibot.packages.__path__ = self.config.get("package-path", [])
 
 	def _write_config(self):
-		with open("config.json", "w") as f:
+		with open(os.path.join(self.workdir, "config.json"), "w") as f:
 			f.write(json.dumps(self.config, sort_keys=True, indent=4))
 
 

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -74,6 +74,11 @@ class Halibot():
 			self.config = json.loads(f.read())
 			halibot.packages.__path__ = self.config.get("package-path", [])
 
+	def _write_config(self):
+		with open("config.json", "w") as f:
+			f.write(json.dumps(self.config, sort_keys=True, indent=4))
+
+
 	def _get_class_from_package(self, pkgname, clsname):
 		pkg = self.get_package(pkgname)
 		if pkg == None:

--- a/main.py
+++ b/main.py
@@ -259,8 +259,7 @@ def h_add(args):
 
 		bot.config[destkey][name] = conf
 
-	with open("config.json","w") as f:
-		f.write(json.dumps(bot.config, sort_keys=True, indent=4))
+	bot._write_config()
 
 def h_rm(args):
 	# In order to access the config easily
@@ -277,8 +276,7 @@ def h_rm(args):
 			continue
 		print("Removed '{}'.".format(name))
 
-	with open("config.json", "w") as f:
-		f.write(json.dumps(bot.config, sort_keys=True, indent=4))
+	bot._write_config()
 
 def h_config(args):
 	# In order to access the config easily
@@ -360,8 +358,7 @@ def h_config(args):
 			(name, conf) = cls.configure(pkgconf, name=args.name)
 			bot.config[destkey][name] = conf
 
-		with open("config.json", "w") as f:
-			f.write(json.dumps(bot.config, sort_keys=True, indent=4))
+		bot._write_config()
 
 if __name__ == "__main__":
 	subcmds = {

--- a/main.py
+++ b/main.py
@@ -66,15 +66,15 @@ def h_run(args):
 	logfile = None
 	loglevel = logging.DEBUG
 	loglevel_str = "DEBUG"
-	loglevels = { 
-		"CRITICAL": logging.CRITICAL, 
-		"ERROR": logging.ERROR, 
-		"WARNING": logging.WARNING, 
+	loglevels = {
+		"CRITICAL": logging.CRITICAL,
+		"ERROR": logging.ERROR,
+		"WARNING": logging.WARNING,
 		"INFO": logging.INFO,
-		"DEBUG": logging.DEBUG, 
+		"DEBUG": logging.DEBUG,
 		"NOTSET": logging.NOTSET
 	}
-	
+
 	# Set log level if argument is provided
 	if args.log_level:
 		loglevel_str = args.log_level


### PR DESCRIPTION
In `main.py`, we use the `Halibot` class to load the config, so we might as well write the config using it as well. We should probably consider a kwarg to `Halibot` for `config_path`, so we can stop hardcoding `"config.json"` everywhere -- it can be a command line argument if people really want to change it. Or if we decide that it should be `"halibot.json"` (which I'm starting to think might be better for clarity), it would be easier to fix everywhere.

Also included is a patch that cleans up some trailing whitespace. Figured it didn't need its own PR.