### PR TITLE
halobject: replace traceback with a call to logging system instead

### DIFF
--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -1,4 +1,4 @@
-import logging, traceback
+import logging
 import asyncio
 import inspect
 import copy
@@ -88,7 +88,7 @@ class HalObject():
 				# Generic receive function
 				self.receive(msg)
 		except Exception as e:
-			traceback.print_exc()
+			self.log.error("Exception in message receive", exc_info=True)
 
 	def receive(self, msg):
 		pass


### PR DESCRIPTION
If there is an unhandled exception in a _receive() handler, error should be
logged instead of just printed to the console. This should also play nicer
with cli/gui wrappers as well.