### PR TITLE
sjrct's route implementation

### DIFF
--- a/halibot/halagent.py
+++ b/halibot/halagent.py
@@ -1,15 +1,4 @@
 from .halobject import HalObject
 
 class HalAgent(HalObject):
-
-	def dispatch(self, msg):
-		out = self.config.get('out', self._hal.objects.modules.keys())
-		self.send_to(msg, out)
-
-	def connect(self, to):
-		# FIXME Don't modify the config like this?
-		if 'out' in self.config:
-			self.config['out'].append(to.name)
-		else:
-			self.config['out'] = [ to.name ]
-
+	pass

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -32,10 +32,6 @@ class ObjectDict(dict):
 class Halibot():
 
 	VERSION = "0.2.0"
-
-	config = {}
-
-	running = False
 	log = None
 
 	def __init__(self, **kwargs):
@@ -47,6 +43,8 @@ class Halibot():
 
 		self.auth = HalAuth()
 		self.objects = ObjectDict()
+		self.config = {}
+		self.running = False
 
 	# Start the Hal instance
 	def start(self, block=True):

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -78,6 +78,14 @@ class HalObject():
 				r[name] = to.sync_replies.pop(msg.uuid)
 		return r
 
+	def dispatch(self, msg):
+		dest = self._hal.route(self.name)
+		self.send_to(msg, dest)
+
+	def sync_dispatch(self, msg):
+		dest = self._hal.route(self.name)
+		self.sync_send_to(msg, dest)
+
 	async def _receive(self, msg):
 		try:
 			fname = 'receive_' + msg.type

--- a/main.py
+++ b/main.py
@@ -259,6 +259,13 @@ def h_add(args):
 
 		bot.config[destkey][name] = conf
 
+		# Add default route
+		if destkey == "module-instances":
+			bot.add_route("@default-container", name)
+		else:
+			bot.add_route(name, "@default-container")
+
+
 	bot._write_config()
 
 def h_rm(args):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -105,9 +105,9 @@ class TestCore(util.HalibotTestCase):
 
 		agent.dispatch(foo) # 0
 		agent.send_to(bar, [ 'stub_mod/able', 'stub_mod2/baker' ] ) # 1
-		agent.connect(mod)
+		self.bot.add_route('stub_agent', 'stub_mod')
 		agent.dispatch(baz) # 2
-		agent.connect(mod2)
+		self.bot.add_route('stub_agent', 'stub_mod2')
 		agent.dispatch(qua) # 3
 
 		agent.dispatch(qua2) # 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,8 +95,8 @@ class TestCore(util.HalibotTestCase):
 		self.bot.add_instance('stub_mod', mod)
 		self.bot.add_instance('stub_mod2', mod2)
 
-		# mod should receive: foo, bar, baz, qua
-		# mod2 should receive: foo, bar, qua
+		# mod should receive: bar, baz, qua
+		# mod2 should receive: bar, qua
 		foo = halibot.Message(body='foo')
 		bar = halibot.Message(body='bar')
 		baz = halibot.Message(body='baz', origin='glub_agent')
@@ -112,48 +112,39 @@ class TestCore(util.HalibotTestCase):
 
 		agent.dispatch(qua2) # 3
 
-		util.waitOrTimeout(100, lambda: len(mod.received) == 4 and len(mod2.received) == 3 and len(mod.received_mytype) == 1 and len(mod2.received_mytype) == 1)
+		util.waitOrTimeout(100, lambda: len(mod.received) == 3 and len(mod2.received) == 2 and len(mod.received_mytype) == 1 and len(mod2.received_mytype) == 1)
 
 		# Check mod received mesages
-		self.assertEqual(4, len(mod.received))
-		self.assertEqual(foo.body, mod.received[0].body)
-		self.assertEqual(bar.body, mod.received[1].body)
-		self.assertEqual(baz.body, mod.received[2].body)
-		self.assertEqual(qua.body, mod.received[3].body)
-		self.assertEqual('', mod.received[0].whom())
-		self.assertEqual('able', mod.received[1].whom())
+		self.assertEqual(3, len(mod.received))
+		self.assertEqual(bar.body, mod.received[0].body)
+		self.assertEqual(baz.body, mod.received[1].body)
+		self.assertEqual(qua.body, mod.received[2].body)
+		self.assertEqual('able', mod.received[0].whom())
+		self.assertEqual('', mod.received[1].whom())
 		self.assertEqual('', mod.received[2].whom())
-		self.assertEqual('', mod.received[3].whom())
-		self.assertEqual('stub_mod', mod.received[0].target)
-		self.assertEqual('stub_mod/able', mod.received[1].target)
+		self.assertEqual('stub_mod/able', mod.received[0].target)
+		self.assertEqual('stub_mod', mod.received[1].target)
 		self.assertEqual('stub_mod', mod.received[2].target)
-		self.assertEqual('stub_mod', mod.received[3].target)
 		self.assertEqual('stub_agent', mod.received[0].origin)
-		self.assertEqual('stub_agent', mod.received[1].origin)
-		self.assertEqual('glub_agent', mod.received[2].origin)
-		self.assertEqual('stub_agent', mod.received[3].origin)
+		self.assertEqual('glub_agent', mod.received[1].origin)
+		self.assertEqual('stub_agent', mod.received[2].origin)
 
 		# Check mod2 received mesages
-		self.assertEqual(3, len(mod2.received))
-		self.assertEqual(foo.body, mod2.received[0].body)
-		self.assertEqual(bar.body, mod2.received[1].body)
-		self.assertEqual(qua.body, mod2.received[2].body)
-		self.assertEqual('', mod.received[0].whom())
-		self.assertEqual('able', mod.received[1].whom())
-		self.assertEqual('', mod.received[2].whom())
-		self.assertEqual('stub_mod2', mod2.received[0].target)
-		self.assertEqual('stub_mod2/baker', mod2.received[1].target)
-		self.assertEqual('stub_mod2', mod2.received[2].target)
+		self.assertEqual(2, len(mod2.received))
+		self.assertEqual(bar.body, mod2.received[0].body)
+		self.assertEqual(qua.body, mod2.received[1].body)
+		self.assertEqual('able', mod.received[0].whom())
+		self.assertEqual('', mod.received[1].whom())
+		self.assertEqual('stub_mod2/baker', mod2.received[0].target)
+		self.assertEqual('stub_mod2', mod2.received[1].target)
 		self.assertEqual('stub_agent', mod2.received[0].origin)
 		self.assertEqual('stub_agent', mod2.received[1].origin)
-		self.assertEqual('stub_agent', mod2.received[2].origin)
 
 		# Check mytype messages
 		self.assertEqual(1, len(mod.received_mytype))
 		self.assertEqual(1, len(mod2.received_mytype))
 		self.assertEqual(qua2.body, mod.received_mytype[0].body)
 		self.assertEqual(qua2.body, mod2.received_mytype[0].body)
-
 
 	def test_send_reply(self):
 		agent = StubAgent(self.bot)
@@ -265,6 +256,7 @@ class TestCore(util.HalibotTestCase):
 		agent = StubAgent(self.bot)
 		self.bot.add_instance('stub_cagent', agent)
 		self.bot.add_instance('stub_cmodule', mod)
+		self.bot.add_route('stub_cagent', 'stub_cmodule')
 
 		# Test regular bare string args
 		foo = halibot.Message(body='foo')
@@ -351,6 +343,8 @@ class TestCore(util.HalibotTestCase):
 		self.bot.add_instance("stub_invoker", inv)
 		self.bot.add_instance("stub_target", tar)
 		self.bot.add_instance("stub_agent", agent)
+		self.bot.add_route("stub_agent", "stub_invoker")
+		self.bot.add_route("stub_agent", "stub_target")
 
 		agent.dispatch(halibot.Message(body="bar"))
 
@@ -374,6 +368,7 @@ class TestCore(util.HalibotTestCase):
 
 		self.bot.add_instance("stub_agent", agent)
 		self.bot.add_instance("stub_mod", mod)
+		self.bot.add_route("stub_agent", "stub_mod")
 
 		self.assertEqual(0, len(agent.received))
 


### PR DESCRIPTION
This is a potential implementation. there are other options that are being discussed.

This flavor uses the '@' prefix to mark what is an is not a container or alias (an intermediary destination).

Example of routes key:
```json
"routes": [
  { "@container": [ "module1", "module2" ]
  , "@container2": [ "@container", "secret-module" ]
  , "special-agent-1": "@container2"
  , "special-agent-2": "@container2"
  },
  { ".*": "@container"
  }
]
```
