### PR TITLE
halconfigurer: Overhaul of configurer, see below for details

### DIFF
--- a/main.py
+++ b/main.py
@@ -251,13 +251,24 @@ def h_add(args):
 				print("Cannot determine if '{}' is a module or agent, use '-m' or '-a'.")
 				continue
 
-		(name, conf) = cls.configure({ 'of': clspath })
+		#(name, conf) = cls.configure({ 'of': clspath })
+		name = input("Enter instance name: ")
+		# TODO: Consider putting this logic into a lib function?
+		cfgr = cls.Configurer()
+		tmpcfg = {}
+		for key,opt in cfgr.options.items():
+			if opt.depends and not tmpcfg.get(opt.depends, False):
+				continue # Skip items that are dependent on a false-booleaned parameter
+
+			tmpcfg[key] = opt.ask(input)
+
+		tmpcfg["of"] = clspath
 
 		if name in bot.config["agent-instances"] or name in bot.config["module-instances"]:
 			print("Instance name '{}' is already in configuration, please choose a different instance name".format(name))
 			return
 
-		bot.config[destkey][name] = conf
+		bot.config[destkey][name] = tmpcfg
 
 	bot._write_config()
 
@@ -355,8 +366,17 @@ def h_config(args):
 				return
 
 
-			(name, conf) = cls.configure(pkgconf, name=args.name)
-			bot.config[destkey][name] = conf
+			# TODO: Seriously consider putting this logic into a lib function?
+			cfgr = cls.Configurer()
+			tmpcfg = pkgconf
+			for key, opt in cfgr.options.items():
+				if opt.depends and not tmpcfg.get(opt.depends, False):
+					continue # Skip items that are dependent on a false-booleaned parameter
+
+				tmpcfg[key] = opt.ask(input)
+
+			#(name, conf) = cls.configure(pkgconf, name=args.name)
+			bot.config[destkey][args.name] = tmpcfg
 
 		bot._write_config()
 


### PR DESCRIPTION
So this overhaul became a bit more of a mess than expected, but I'm liking so far how it is coming out.

I had two main objectives:
1. Allow validation of preexisting config blobs
2. Allow validation of individual config keys/items.

So far, both of these options probably should work, I will be updating this branch as I fix/tweak things.

Changelog (so far):

- `.configure()` method of internal HalConfigurer objects now defines a list of option strings
- External callers should now instantiate a HalConfigurer object, and either iterate through the options and call `.ask()`, or `.validate()` an option
- `.ask()` now takes a function argument for how to receive the value
- added a `depends=` optional parameter to options, since `.configure()` on `HalConfigurer` objects no longer is the code that prompts users, therefore breaking conditional prompts like in `irc`


**NOTE:** I am unable to test any of these changes outside of the `main.py` cli due to https://github.com/halibot-extra/irc/issues/3, hooray