### PR TITLE
Move Package Management Logic to a Module

### DIFF
--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -33,8 +33,6 @@ class Halibot():
 
 	VERSION = "0.2.0"
 
-	config = {}
-
 	running = False
 	log = None
 
@@ -44,6 +42,11 @@ class Halibot():
 		self.use_config = kwargs.get("use_config", True)
 		self.use_auth = kwargs.get("use_auth", True)
 		self.workdir = kwargs.get("workdir", ".")
+		self.config = kwargs.get("config", {})
+		if self.config:
+			halibot.packages.__path__ = self.config.get("package-path", [])
+
+		self.configfile = kwargs.get("configfile", "config.json")
 
 		self.auth = HalAuth()
 		self.objects = ObjectDict()
@@ -53,7 +56,8 @@ class Halibot():
 		self.running = True
 
 		if self.use_config:
-			self._load_config()
+			if not self.config:
+				self._load_config(configfile=self.configfile)
 			self._instantiate_objects("agent")
 			self._instantiate_objects("module")
 			if self.use_auth:
@@ -89,13 +93,13 @@ class Halibot():
 		inst.init()
 		self.log.info("Instantiated object '" + name + "'")
 
-	def _load_config(self):
-		with open(os.path.join(self.workdir, "config.json"), "r") as f:
+	def _load_config(self, configfile="config.json"):
+		with open(os.path.join(self.workdir, configfile), "r") as f:
 			self.config = json.loads(f.read())
 			halibot.packages.__path__ = self.config.get("package-path", [])
 
-	def _write_config(self):
-		with open(os.path.join(self.workdir, "config.json"), "w") as f:
+	def _write_config(self, configfile="config.json"):
+		with open(os.path.join(self.workdir, configfile), "w") as f:
 			f.write(json.dumps(self.config, sort_keys=True, indent=4))
 
 

--- a/packages/core/__init__.py
+++ b/packages/core/__init__.py
@@ -1,2 +1,3 @@
-
+from .pm import PackageManager
 from .help import Help
+Default = None

--- a/packages/core/pm.py
+++ b/packages/core/pm.py
@@ -1,0 +1,150 @@
+import urllib.request
+import tarfile
+import io
+import os
+import argparse
+import json
+from halibot import HalModule
+
+class PackageManager(HalModule):
+
+	VERSION = "0.3.0"
+	HAL_MINIMUM = "0.2.0"
+
+	def init(self):
+		self.commands = {
+			"fetch":    self.h_fetch,
+			"unfetch":  self.h_unfetch,
+			"search":   self.h_search,
+			"packages": self.h_list_packages
+		}
+
+		self.parser = argparse.ArgumentParser(description="PackageManager")
+		self.cli(self.parser.add_subparsers(title="Package Management"))
+
+	def receive(self, msg):
+		if not msg.body.startswith("!"):
+			return
+
+		ls = msg.body[1:].split(" ")
+		args = self.parser.parse_args(ls)
+
+		func = self.commands.get(args.cmd)
+		if not func:
+			self.reply(msg, body="Command '{}' not found".format(args.cmd))
+			return
+
+		func(args, output=lambda x: output(x))
+
+	def cli_receive(self, args):
+		func = self.commands.get(args.cmd)
+		if not func:
+			return False
+
+		func(args, output=print)
+		return True
+
+	# Expose the CLI argument logic
+	def cli(self, parser):
+		fetch = parser.add_parser("fetch", help="fetch remote packages")
+		fetch.add_argument("packages", help="name of package to fetch", nargs="+", metavar="package")
+
+		unfetch = parser.add_parser("unfetch", help="as if you never fetched them at all")
+		unfetch.add_argument("packages", help="name of package to unfetch", nargs="+", metavar="package")
+
+		search = parser.add_parser("search", help="search for packages")
+		search.add_argument("term", help="what to search for", nargs="?", metavar="term")
+
+		list_packages = parser.add_parser("packages", help="list all installed packages")
+
+
+	def h_fetch(self, args, output):
+		# In order to access the config easily
+		bot = self._hal
+
+		# Error checking
+		if not "repos" in bot.config:
+			output("There are no repos specified in the config.json.")
+			output("I have nothing to fetch from!")
+			return
+
+		# Try to fetch each requested package
+		for name in args.packages:
+			# Install to the first package path by default
+			dst = os.path.join(bot.config["package-path"][0], name)
+
+			success = False
+			for r in bot.config["repos"]:
+				src = r + "/fetch/" + name
+				try:
+					output("Trying to fetch package from '{}'...".format(r))
+					bio = io.BytesIO(urllib.request.urlopen(src).read())
+					tar = tarfile.open(mode="r:*", fileobj=bio)
+					os.mkdir(dst)
+					tar.extractall(dst)
+
+					output("\033[92mSuccessfully fetched '{}' into '{}'.\033[0m".format(name, dst))
+					success = True
+					break
+				except Exception as e:
+					output("Exception in pm: {}".format(e))
+
+			if not success:
+				output("\033[91mFailed to fetch '{}'!\033[0m".format(name))
+
+	def h_search(self, args, output):
+		# In order to access the config easily
+		bot = self._hal
+
+		# Error checking
+		if not "repos" in bot.config:
+			print("There are no repos specified in the config.json.")
+			print("I have nowhere to search!")
+			return
+
+		# Query all listed repositories
+		results = {}
+		for r in bot.config["repos"]:
+			url = r + "/search/"
+			if args.term != None:
+				url += args.term
+
+			data = urllib.request.urlopen(url).read().decode('utf-8')
+			subres = json.loads(data)
+			results = dict(list(subres.items()) + list(results.items()))
+
+		# Output results
+		sorted_keys = list(results.keys())
+		sorted_keys.sort()
+		for name in sorted_keys:
+			print(name, "-", results[name]['description'])
+
+
+	def h_unfetch(self, args, output):
+		# In order to access the config easily
+		bot = self._hal
+
+		# Remove each requested package
+		for name in args.packages:
+			# Install to the first package path by default
+			success = False
+			for pkgpath in bot.config["package-path"]:
+				path = os.path.join(pkgpath, name)
+				if os.path.exists(path):
+					shutil.rmtree(path)
+					output("Removed '{}' installed to '{}'.".format(name, path))
+					success = True
+
+			if not success:
+				output("Could not find package '{}'".format(name))
+
+
+	def h_list_packages(self, args, output):
+		bot = self._hal
+
+		pkgs = []
+		for path in bot.config.get("package-path"):
+			pkgs = pkgs + os.listdir(path)
+		pkgs.sort()
+
+		output("Installed packages: " + ", ".join(pkgs))


### PR DESCRIPTION
**THIS IS A VERY RFC PATCH, DO NOT MERGE**

Moral of this PR: Why do things in `main.py`, when we can share that logic with a module?

This is a crazy hacky RFC to demonstrate a method of implementing logic that is meant to be shared between the CLI and an actual running instance. Due to https://github.com/halibot-extra/irc/issues/3 , I'm not able to test the runtime portion yet, but surprisingly the CLI portion does.

 ## General idea:
Add a new `-instances` list to `config.json` called `cli-instances`, which are only ever loaded from `main.py`. Only modules that implement `.cli()` (final name TBD) and `.cli_receive()` (also needs fixing) should be ever listed there. The `.cli()` call takes in the command subparser from `main.py`, and adds whatever commands it supports there. The `.cli_receive()` makes the actual call.

## Why.
Well, doing it this way meant I only needed to change how to print out information. Plus, we don't need to depend on routing or any other weird stuff yet to figure out when the CLI commands need to show up at all. For now, this will lead to a much simpler and smaller `main.py`, and the module side of things isn't any more complex than it was before.

Look forward to a `!config` module using the similar pattern coming soon, probably based off of this branch.

## Other notes:

- This PR somewhat depends on #113 , so please check and merge that one long before caring about this one.
- I'm ignoring Travis again, since this will probably break all the tests yet again.
- This will most assuredly require a version bump, I suggest we either merge this into an `for-0.3.0` branch, or bump version shortly after