### PR TITLE
Some small tweaks and "fixes" to halauth

### DIFF
--- a/halibot/halauth.py
+++ b/halibot/halauth.py
@@ -1,12 +1,27 @@
 import json
 import logging
 import re
+from halibot.message import Message, MalformedMsgException
 
-def hasPermission(perm, reply=False):
+def hasPermission(perm, reply=False, argnum=None, key="msg"):
 	def real_dec(func):
-		def wrapper(self, msg, *args, **kwargs):
+		def wrapper(self, *args, **kwargs):
+			if argnum != None and argnum < len(args):
+				msg = args[argnum]
+			else:
+				msg = kwargs[key]
+
+			# Origin must be set for this to be a valid permission check
+			if not hasattr(msg, "origin") or not msg.origin:
+				self.log.error("Probable module bug! -- hasPermission decorator called on a function that doesn't have a valid Message argument!")
+				raise MalformedMsgException("Bad or missing origin attribute")
+			# Identity may not be supported by agent, so we'll allow this to be blank
+			if not hasattr(msg, "identity"):
+				self.log.error("Probable module bug! -- hasPermission decorator called on a function that doesn't have a valid Message argument!")
+				raise MalformedMsgException("Missing identity attribute")
+
 			if self._hal.auth.hasPermission(msg.origin, msg.identity, perm):
-				func(self, msg, *args, **kwargs)
+				func(self, *args, **kwargs)
 			elif reply:
 				self.reply(msg, body="Permission Denied")
 		return wrapper

--- a/halibot/message.py
+++ b/halibot/message.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from .jsdict import jsdict
 
+class MalformedMsgException(Exception): 'Bad message object'
+
 class Message():
 
 	def __init__(self, **kwargs):


### PR DESCRIPTION
~Pretty straightforward PR, nothing invasive this time.~

- ~1898759 returns a boolean based on if `.grant` or `.revoke` actually did something to the internal permissions list -- largely as an indicator to the caller if they should bother calling `.write`~
- ~fe3cfc2 changes the behavior of the `@hasPermission` decorator slightly, to no longer require the `Message` object it parses `ri` and `identity` from as a positional argument. Best to look at the code/commit message for more info.~

Haha jk wasn't straightforward at all. See comments for what happened.