### PR TITLE
Implement a PermissionManager core module

### DIFF
--- a/halibot/halauth.py
+++ b/halibot/halauth.py
@@ -1,11 +1,21 @@
 import json
 import logging
+from halibot.message import Message
 
 def hasPermission(perm, reply=False):
 	def real_dec(func):
-		def wrapper(self, msg, *args, **kwargs):
+		def wrapper(self, *args, **kwargs):
+			msg = None
+			for i in list(args) + list(kwargs.values()):
+				if i.__class__ == Message:
+					msg = i
+					break
+			else:
+				self.log.error("Probable module bug! -- hasPermission decorator called on a function that doesn't have a Message argument!")
+				return
+
 			if self._hal.auth.hasPermission(msg.origin, msg.identity, perm):
-				func(self, msg, *args, **kwargs)
+				func(self, *args, **kwargs)
 			elif reply:
 				self.reply(msg, body="Permission Denied")
 		return wrapper

--- a/halibot/halauth.py
+++ b/halibot/halauth.py
@@ -47,20 +47,24 @@ class HalAuth():
 
 	def grantPermission(self, ri, identity, perm):
 		if not self.enabled:
-			return
+			return False
 
 		t = (ri, identity, perm)
 		if t not in self.perms:
 			self.perms.append(t)
+			return True
+		return False
 
 	def revokePermission(self, ri, identity, perm):
 		if not self.enabled:
-			return
+			return False
 
 		try:
 			self.perms.remove((ri,identity, perm))
+			return True
 		except Exception as e:
 			self.log.error("Revocation failed: {}".format(e))
+			return False
 
 	def hasPermission(self, ri, identity, perm):
 		if not self.enabled:

--- a/packages/core/__init__.py
+++ b/packages/core/__init__.py
@@ -1,2 +1,3 @@
 
 from .help import Help
+from .perm import PermissionManager

--- a/packages/core/perm.py
+++ b/packages/core/perm.py
@@ -1,0 +1,31 @@
+from halibot import CommandModule
+from halibot.halauth import hasPermission
+
+class PermissionManager(CommandModule):
+	def init(self):
+		self.commands = {
+			"grant":  self.grant_,
+			"revoke": self.revoke_,
+		}
+
+	@hasPermission("PERM_GRANT", reply=True)
+	def grant_(self, argv, msg=None):
+		try:
+			ri, identity, perm = argv.split(" ")
+		except:
+			self.reply(msg, body="Must be in the form '<ri> <identity> <perm>'")
+			return
+
+		if self._hal.auth.grantPermission(ri, identity, perm):
+			self._hal.auth.write_perms()
+
+	@hasPermission("PERM_REVOKE", reply=True)
+	def revoke_(self, argv, msg=None):
+		try:
+			ri, identity, perm = argv.split(" ")
+		except:
+			self.reply(msg, body="Must be in the form '<ri> <identity> <perm>'")
+			return
+
+		if self._hal.auth.revokePermission(ri, identity, perm):
+			self._hal.auth.write_perms()


### PR DESCRIPTION
Permissions have been long ignored in Halibot, largely because there hasn't been a convenient way to manipulate them. This commit adds a core module to expose some commands for runtime permission management.

There is a bit of a chicken-and-egg problem with this, as you need to grant yourself the permission to edit permissions first. This is a prime candidate for a future CLI-enabled module, but I figured it was better to release this first while #113 is still up in the air.

This branch depends on #115 , since it needs the fixed decorator thanks to the previous implementation's incompatibility with `CommandModule`.

Question: Should `PERM_GRANT` and `PERM_REVOKE` be merged into a single `PERM_EDIT` permission?