### PR TITLE
halibot: Changes use-auth parameter from kwarg to config param, adds …

### DIFF
--- a/halibot/halauth.py
+++ b/halibot/halauth.py
@@ -31,6 +31,7 @@ class HalAuth():
 
 		except Exception as e:
 			self.log.error("Error loading permissions: {}".format(e))
+			self.perms = []
 			# Return if can't find auth?
 
 		self.enabled = True

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -42,7 +42,6 @@ class Halibot():
 		self.log = logging.getLogger(self.__class__.__name__)
 
 		self.use_config = kwargs.get("use_config", True)
-		self.use_auth = kwargs.get("use_auth", True)
 		self.workdir = kwargs.get("workdir", ".")
 
 		self.auth = HalAuth()
@@ -56,7 +55,7 @@ class Halibot():
 			self._load_config()
 			self._instantiate_objects("agent")
 			self._instantiate_objects("module")
-			if self.use_auth:
+			if self.config.get("use-auth", False):
 				self.auth.load_perms(self.config.get("auth-path","permissions.json"))
 
 	def shutdown(self):

--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ def h_init(args):
 		],
 		"repos": ["https://halibot.fish:4842"],
 		"agent-instances": {},
-		"module-instances": {}
+		"module-instances": {},
+		"use-auth": False
 	}
 
 	with open(confpath, "w") as f:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -117,6 +117,14 @@ class TestAuth(util.HalibotTestCase):
 		self.assertFalse(stub.called)
 
 	def test_load_perms(self):
+		# A bad JSON string should give the user no permissions
+		with open("testperms.json", "w") as f:
+			f.write("[(\"foo\", \"bar\", \"baz\")]")
+
+		self.bot.auth.load_perms("testperms.json")
+		self.assertEqual(len(self.bot.auth.perms), 0)
+		self.assertTrue(self.bot.auth.enabled)
+
 		with open("testperms.json", "w") as f:
 			f.write("[]")
 


### PR DESCRIPTION
…more error-proofing for faulty permissions file

For https://github.com/Halibot/halibot/issues/118