### PR TITLE
halibot: adds repr and str functions for message class

### DIFF
--- a/halibot/message.py
+++ b/halibot/message.py
@@ -19,3 +19,9 @@ class Message():
 
 	def whom(self):
 		return '/'.join(self.target.split('/')[1:])
+
+	def __repr__(self):
+		return "halibot.Message(body='{}', type='{}', author='{}', identity='{}', origin='{}', misc='{}', target='{}')".format(self.body, self.type, self.author, self.identity, self.origin, self.misc, self.target)
+
+	def __str__(self):
+		return "body='{}' type='{}' author='{}' origin='{}' target='{}'".format(self.body, self.type, self.author, self.origin, self.target)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,30 @@
+import util
+import halibot
+import unittest
+
+testMessage = halibot.Message(body="foo", type="bar", author="Foo Barrington", identity="yes", origin="Assyria", misc="[\"foo\", \"bar\"]", target="bees?")
+
+class TestMessage(util.HalibotTestCase):
+	def testCreation(self):
+		self.assertEqual("foo", testMessage.body)
+		self.assertEqual("bar", testMessage.type)
+		self.assertEqual("Foo Barrington", testMessage.author)
+		self.assertEqual("yes", testMessage.identity)
+		self.assertEqual("Assyria", testMessage.origin)
+		self.assertEqual("[\"foo\", \"bar\"]", testMessage.misc)
+		self.assertEqual("bees?", testMessage.target)
+
+	# Test that repr will eval to a duplicate message
+	def testRepr(self):
+		m = eval(testMessage.__repr__())
+
+		self.assertEqual("foo", m.body)
+		self.assertEqual("bar", m.type)
+		self.assertEqual("Foo Barrington", m.author)
+		self.assertEqual("yes", m.identity)
+		self.assertEqual("Assyria", m.origin)
+		self.assertEqual("[\"foo\", \"bar\"]", m.misc)
+		self.assertEqual("bees?", m.target)
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Perhaps we can open up some discussion for how we want to show message information but we can utilize both repr() (for verbose object printing) and str() (for readable object printing) if we want, but what we want to display in str() is up for discussion. Also, I'm not sure what the process is for adding new tests but I wanted to verify I could recreate a message from repr(). If the tests don't make sense or should go somewhere else, please let me know.

Also, for reference: https://github.com/Halibot/halibot/issues/97