### PR TITLE
halauth: adds regex support for ri and perm fields of permissions

### DIFF
--- a/halibot/halauth.py
+++ b/halibot/halauth.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 def hasPermission(perm, reply=False):
 	def real_dec(func):
@@ -68,7 +69,7 @@ class HalAuth():
 
 		def tester(x):
 			a,b,c = x
-			return a in (ri, "*") and b in (identity, "*") and c in (perm, "*")
+			return re.match(a, ri) and b in (identity, "*") and re.match(c, perm)
 
 		# Return True on the first successful perm match
 		for l in self.perms:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -116,6 +116,20 @@ class TestAuth(util.HalibotTestCase):
 		stub.receive(msg)
 		self.assertFalse(stub.called)
 
+	def test_hasperm_regex(self):
+		self.bot.auth.enabled = True
+		stub = StubModuleDec(self.bot)
+		self.bot.add_instance('stub_mod', stub)
+
+		ri = "test/foobar"
+		user = "tester"
+		perm = "Foo"
+		msg = halibot.Message(body="", origin=ri, identity=user)
+
+		self.bot.auth.grantPermission(".*", user, ".*")
+		stub.receive(msg)
+		self.assertTrue(stub.called)
+
 	def test_load_perms(self):
 		with open("testperms.json", "w") as f:
 			f.write("[]")


### PR DESCRIPTION
We can probably rework the permissions loading system as well to better handle regexes, making this more robust. Feel free to leave on comments on any ideas you might have.