### PR TITLE
Implement local/system configs

### DIFF
--- a/config/system.json
+++ b/config/system.json
@@ -1,0 +1,5 @@
+{
+	"package-path": [
+		"${HALDIR}/packages"
+	]
+}

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -147,7 +147,7 @@ class Halibot():
 				text = Template(f.read()).safe_substitute(**specials)
 				self.config.set_system(json.loads(text))
 		except FileNotFoundError as _:
-			self.log.info("No sytem config loaded.")
+			self.log.info("No system config loaded.")
 
 	def _write_config(self):
 		with open(os.path.join(self.workdir, "config.json"), "w") as f:

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,8 @@ function install {
 	mkdir -p $SRCLOC &&
 	cp $VERBOSE main.py $SRCLOC &&
 	cp -r $VERBOSE halibot $SRCLOC/halibot &&
-	cp -r $VERBOSE packages $SRCLOC/packages
+	cp -r $VERBOSE packages $SRCLOC/packages &&
+	cp -r $VERBOSE config $SRCLOC/config &&
 }
 
 # Handle arguments

--- a/main.py
+++ b/main.py
@@ -32,8 +32,7 @@ def h_init(args):
 
 	config = {
 		"package-path": [
-			"packages",
-			os.path.join(os.path.abspath(os.path.dirname(__file__)), "packages")
+			"packages"
 		],
 		"repos": ["https://halibot.fish:4842"],
 		"agent-instances": {},


### PR DESCRIPTION
This adds support for separate local and system configs. The principle use case is for globally installed packages that can be accessed by anyone.

Had to add a special variable to halibot configs. If this was not done, then there would no way to keep the system config pointing to the source package path without doing some substitution or something in install.sh, which is not ideal as it would not work out-of-the-box, only after installation.

Fixes #122 and fixes #121.