### PR TITLE
Info command for CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,6 +196,37 @@ def h_unfetch(args):
 		if not success:
 			print("Could not find package '{}'".format(name))
 
+def h_info(args):
+	bot = halibot.Halibot()
+	bot._load_config()
+
+	if args.object_name:
+		# Show configuration of specific object
+
+		conf = bot.config["agent-instances"].get(args.object_name)
+		conf = bot.config["module-instances"].get(args.object_name) if not conf else conf
+		if not conf:
+			print("No such agent or module")
+			return
+
+		print(f"\n{args.object_name}: ({conf['of']})")
+		for k in conf:
+			if k != "of":
+				print(f"  {k}: {conf[k]}")
+	else:
+		# Show all configured objects
+		print("\nConfigured agents:")
+		agents = bot.config.get("agent-instances")
+		for name in agents:
+			print(f"  {name} ({agents[name]['of']})")
+
+		print("\nConfigured modules:")
+		modules = bot.config.get("module-instances")
+		for name in modules:
+			print(f"  {name} ({modules[name]['of']})")
+
+	print("")
+
 
 def h_list_packages(args):
 	bot = halibot.Halibot()
@@ -371,6 +402,7 @@ if __name__ == "__main__":
 		"packages": h_list_packages,
 		"search": h_search,
 		"config": h_config,
+		"info": h_info,
 	}
 
 	# Setup argument parsing
@@ -412,6 +444,9 @@ if __name__ == "__main__":
 	config_cmd.add_argument("-k", "--key", help="key to set or key to display with -s", required=False)
 	config_cmd.add_argument("-v", "--value", help="value to set key to", required=False)
 	config_cmd.add_argument("-t", "--type", choices=["string", "number", "boolean"], help="the type used while setting a config value with -k. If not given, it uses the type of the existing value")
+
+	info = sub.add_parser("info", help="show configuration information")
+	info.add_argument("object_name", nargs="?", help="name of module or adent to query about")
 
 	args = parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -203,8 +203,8 @@ def h_info(args):
 	if args.object_name:
 		# Show configuration of specific object
 
-		conf = bot.config["agent-instances"].get(args.object_name)
-		conf = bot.config["module-instances"].get(args.object_name) if not conf else conf
+		conf = bot.config.get("agent-instances", {}).get(args.object_name)
+		conf = bot.config.get("module-instances", {}).get(args.object_name) if not conf else conf
 		if not conf:
 			print("No such agent or module")
 			return
@@ -215,15 +215,17 @@ def h_info(args):
 				print(f"  {k}: {conf[k]}")
 	else:
 		# Show all configured objects
-		print("\nConfigured agents:")
-		agents = bot.config.get("agent-instances")
-		for name in agents:
-			print(f"  {name} ({agents[name]['of']})")
+		if len(bot.config.get("agent-instances", {})) > 0:
+			print("\nConfigured agents:")
+			agents = bot.config["agent-instances"]
+			for name in agents:
+				print(f"  {name} ({agents[name]['of']})")
 
-		print("\nConfigured modules:")
-		modules = bot.config.get("module-instances")
-		for name in modules:
-			print(f"  {name} ({modules[name]['of']})")
+		if len(bot.config.get("module-instances", {})) > 0:
+			print("\nConfigured modules:")
+			modules = bot.config.get("module-instances")
+			for name in modules:
+				print(f"  {name} ({modules[name]['of']})")
 
 	print("")
 

--- a/main.py
+++ b/main.py
@@ -237,7 +237,7 @@ def h_list_packages(args):
 		pkgs = pkgs + os.listdir(path)
 	pkgs.sort()
 
-	print("\nInstalled packages:")
+	print("\nAvailable packages:")
 	for p in pkgs:
 		print("  {}".format(p))
 	print("")
@@ -433,7 +433,7 @@ if __name__ == "__main__":
 	rm = sub.add_parser("rm", help="remove agents or modules from the local halibot instance")
 	rm.add_argument("names", help="names of agents or modules to remove", nargs="+", metavar="name")
 
-	list_packages = sub.add_parser("packages", help="list all installed packages")
+	list_packages = sub.add_parser("packages", help="list all available packages")
 
 	search = sub.add_parser("search", help="search for packages")
 	search.add_argument("term", help="what to search for", nargs="?", metavar="term")


### PR DESCRIPTION
This adds and `info` subcommand to the command line interface that output information about the configuration.

 * `halibot info` - shows the agents and modules that are present in the config
 * `halibot info [module|agent]` - shows what config values are set for that module or agent