### PR TITLE
Split raw sending logic into its own function

### DIFF
--- a/halibot/message.py
+++ b/halibot/message.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from .jsdict import jsdict
 
+class MalformedMsgException(Exception): 'Bad message object'
+
 class Message():
 
 	def __init__(self, **kwargs):


### PR DESCRIPTION
Over time, we seem to have made `.send_to()` the default sending function. With discussions over filters and possible routing magic forthcoming, it might be best to split the actual logic that makes the send into its own function. Ideally, this function should *only* send to the given target, and completely ignore any other routing, filter, container, etc logic entirely.

So in short: `.raw_send(msg)` sends `msg` to `msg.target`. Nothing more.

I'm opening this PR separately so we can discuss this here, see #132  for why this was needed.