### PR TITLE
Implement HalFilters via RI injection

### DIFF
--- a/halibot/__init__.py
+++ b/halibot/__init__.py
@@ -1,6 +1,7 @@
 from .halibot import Halibot, Version
 from .halagent import HalAgent
 from .halmodule import HalModule
+from .halfilter import HalFilter
 from .halobject import HalObject, SyncSendSelfException
 from .halconfigurer import HalConfigurer
 from .message import Message

--- a/halibot/halfilter.py
+++ b/halibot/halfilter.py
@@ -1,0 +1,22 @@
+from .halobject import HalObject
+
+class HalFilter(HalObject):
+
+	# Override this in subclasses to determine filter logic
+	#  Return None to reject message
+	#  Otherwise, return the message object with any modifications necessary
+	def filter(self, msg):
+		return msg
+
+	def receive(self, msg):
+		try:
+			# Trim off this filter's target
+			msg.target = msg.target.split("/",1)[1]
+		except:
+			# This shouldn't happen with a proper RI
+			self.log.error("Target RI cannot be split, did someone send this filter a message directly?")
+			return
+
+		msg = self.filter(msg)
+		if msg:
+			self.raw_send(msg)

--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -119,6 +119,7 @@ class Halibot():
 			self.config._load_config()
 			self._instantiate_objects("agent")
 			self._instantiate_objects("module")
+			self._instantiate_objects("filter")
 			if self.config.get("use-auth", False):
 				self.auth.load_perms(self.config.get("auth-path","permissions.json"))
 

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -43,6 +43,21 @@ class HalObject():
 	def shutdown(self):
 		pass
 
+	def apply_filter(self, dest):
+		fl = self._hal.config.get("filters")
+		if not fl:
+			return dest # Filters not enabled/configured
+
+		name = dest.split("/")[0]
+
+		ib = fl.get("inbound", {})
+		ob = fl.get("outbound", {})
+
+		ret = "/".join(ib.get(name, []) + [dest])
+		ret = "/".join(ob.get(self.name, []) + [ret])
+
+		return ret
+
 	def raw_send(self, msg):
 		if not msg.target:
 			self.log.warning("Message passed to send without target")
@@ -67,7 +82,7 @@ class HalObject():
 
 		ret = {}
 		for ri in dests:
-			msg.target = ri
+			msg.target = self.apply_filter(ri)
 			ret[ri] = self.raw_send(msg)
 
 		return ret

--- a/halibot/message.py
+++ b/halibot/message.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from .jsdict import jsdict
 
+class MalformedMsgException(Exception): 'Bad message object'
+
 class Message():
 
 	def __init__(self, **kwargs):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,207 @@
+import util
+import halibot
+import unittest
+import time
+
+# Test that filters are applied correctly
+class StubFilter(halibot.HalFilter):
+	inited = False
+
+	def init(self):
+		self.ran = False
+		self.inited = True
+
+	def filter(self, msg):
+		self.ran = True
+		return msg
+
+# Test if a filter properly accepts/drops messages
+class StubRejectFilter(halibot.HalFilter):
+	inited = False
+
+	def init(self):
+		self.accept = True
+		self.inited = True
+
+	def filter(self, msg):
+		if self.accept:
+			return msg
+		return None
+
+# Test if a filter properly mutates a msg.body
+class StubBodyFilter(halibot.HalFilter):
+	inited = False
+
+	def init(self):
+		self.inited = True
+		self.ran = False
+
+	def filter(self, msg):
+		self.ran = True
+		msg.body += "filtered"
+		return msg
+
+# --- Classes borrowed from test_core ---
+class StubAgent(halibot.HalAgent):
+	inited = False
+
+	def init(self):
+		self.inited = True
+		self.received = []
+
+	def receive(self, msg):
+		self.received.append(msg)
+
+
+class StubReplier(halibot.HalModule):
+	inited = False
+
+	def init(self):
+		self.inited = True
+		self.received = []
+
+	def receive(self, msg):
+		self.received.append(msg)
+		self.reply(msg, body=msg.body + "bar")
+
+# --- end borrow ---
+
+
+
+class TestHalFilter(util.HalibotTestCase):
+
+	def test_inbound_filter(self):
+		# --- Borrowed from test_send_reply ---
+		agent = StubAgent(self.bot)
+		mod = StubReplier(self.bot)
+		filter = StubFilter(self.bot)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_module', mod)
+		self.bot.add_instance('stub_filter', filter)
+
+		self.assertTrue(agent.inited)
+		self.assertTrue(mod.inited)
+		self.assertTrue(filter.inited)
+
+		self.assertTrue(agent.eventloop.is_running())
+		self.assertTrue(mod.eventloop.is_running())
+		self.assertTrue(filter.eventloop.is_running())
+
+		foo = halibot.Message(body='foo')
+		# --- end borrow ---
+
+		self.bot.config["filters"] = {
+			"inbound": {
+				"stub_module": [ "stub_filter" ]
+			}
+		}
+
+		agent.send_to(foo, ['stub_module'])
+
+		util.waitOrTimeout(50, lambda: len(agent.received) != 0)
+
+		self.assertEqual(len(agent.received), 1)
+		self.assertEqual(agent.received[0].body, "foobar")
+		self.assertTrue(filter.ran)
+
+
+	def test_outbound_filter(self):
+		agent = StubAgent(self.bot)
+		mod = StubReplier(self.bot)
+		filter = StubFilter(self.bot)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_module', mod)
+		self.bot.add_instance('stub_filter', filter)
+
+		self.assertTrue(agent.inited)
+		self.assertTrue(mod.inited)
+		self.assertTrue(filter.inited)
+
+		self.assertTrue(agent.eventloop.is_running())
+		self.assertTrue(mod.eventloop.is_running())
+		self.assertTrue(filter.eventloop.is_running())
+
+		foo = halibot.Message(body='foo')
+
+		self.bot.config["filters"] = {
+			"outbound": {
+				"stub_module": [ "stub_filter" ]
+			}
+		}
+
+		agent.send_to(foo, ['stub_module'])
+
+		util.waitOrTimeout(100, lambda: len(agent.received) != 0)
+
+		self.assertEqual(len(agent.received), 1)
+		self.assertEqual(agent.received[0].body, "foobar")
+		self.assertTrue(filter.ran)
+
+	def test_drop_filter(self):
+		agent = StubAgent(self.bot)
+		mod = StubReplier(self.bot)
+		filter = StubRejectFilter(self.bot)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_module', mod)
+		self.bot.add_instance('stub_filter', filter)
+
+		self.assertTrue(agent.inited)
+		self.assertTrue(mod.inited)
+		self.assertTrue(filter.inited)
+
+		self.assertTrue(agent.eventloop.is_running())
+		self.assertTrue(mod.eventloop.is_running())
+		self.assertTrue(filter.eventloop.is_running())
+
+		foo = halibot.Message(body='foo')
+
+		self.bot.config["filters"] = {
+			"inbound": {
+				"stub_module": [ "stub_filter" ]
+			}
+		}
+
+		filter.accept = False
+		agent.send_to(foo, ['stub_module'])
+		time.sleep(1)
+		self.assertEqual(len(agent.received), 0)
+
+		filter.accept = True
+		agent.send_to(foo, ['stub_module'])
+		util.waitOrTimeout(50, lambda: len(agent.received) != 0)
+		self.assertEqual(len(agent.received), 1)
+
+	def test_body_filter(self):
+		agent = StubAgent(self.bot)
+		mod = StubReplier(self.bot)
+		filter = StubBodyFilter(self.bot)
+		self.bot.add_instance('stub_agent', agent)
+		self.bot.add_instance('stub_module', mod)
+		self.bot.add_instance('stub_filter', filter)
+
+		self.assertTrue(agent.inited)
+		self.assertTrue(mod.inited)
+		self.assertTrue(filter.inited)
+
+		self.assertTrue(agent.eventloop.is_running())
+		self.assertTrue(mod.eventloop.is_running())
+		self.assertTrue(filter.eventloop.is_running())
+
+		foo = halibot.Message(body='foo')
+
+		self.bot.config["filters"] = {
+			"outbound": {
+				"stub_module": [ "stub_filter" ]
+			}
+		}
+
+		agent.send_to(foo, ['stub_module'])
+
+		util.waitOrTimeout(50, lambda: len(agent.received) != 0)
+
+		self.assertEqual(len(agent.received), 1)
+		self.assertEqual(agent.received[0].body, "foobarfiltered")
+		self.assertTrue(filter.ran)
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
In the never ending quest to make Halibot aware of its own spam, here is an implementation of filters that inject themselves into a send path based on a `config.json` filter table. Filters are implemented as a new `HalObject` type, and now also have their own `filter-instances` key in `config.json`. See below for an example config.

## Overview
When a message is sent via `.send_to()` (and thus also `.reply()`, `.dispatch()`), the base `HalObject` class first checks the filter table in `config.json` for any filters that may need to be applied. The filter table is a top-level config key `filter`, that contains two sub keys: `inbound` and `outbound`. The inbound key maps a target object to a list of filters that should be applied first. The outbound key maps the *sending* object to a list of filters. The sending logic first prepends any valid inbound filters, then prepends any outbound filters. Finally, the message is sent to the first item in the RI list.

When a filter receives a message object, it first strips off the first item in the RI list. This preserves the chain, and prevents a loop. When the message exits the filter chain, the target should be the original intended target prior to the filter injection. See example below for how this chain resolves.

## Why...
### ...another `HalObject`
I think it makes sense that it maintains its own state, including message queue. A filter may want to simply delay sending a message, instead of outright denying it. A filter may want to modify a message and completely change the target. Also, it's much much much easier to steal all the same module/agent loading logic.

### ...not make this a module?
In this implementation, `HalFilters` take a special role that makes them quite different from other modules or agents. They aren't intended to process the data themselves, only to slightly tweak some magic in between. They are like a detour when traveling, if received at the same destination, it doesn't particularly matter which road was taken to get there.

They also require a bit of extra special magic that hasn't quite made it into Halibot yet: special routing. This allows us to play with a baby version of a routing scheme we discussed long ago, without completely overhauling the current system.

### ...do you need #131 
Because without it, it would send messages in a loop forever.

There needs to be a way to inject the filter's RIs into the target path somehow, so `.send_to` seemed to be a good place to put it. Only then did I realize, it is super easy to get caught in a loop that way. So, I needed `HalFilter` to send a message without any possible accidental filter injection. Thus, `.raw_send` was born: a way to send a message to a target without *any* interference.


## Example `config.json`
```json
{
  "filter-instances": {
    "rlfilter0": {
      "of": "RateLimitFilter:Default",
      "rate": 10
    },
    "rlfilter1": {
      "of": "RateLimitFilter:Default",
      "rate": 6000
    }
  },


  "filters": {
    "inbound": {
      "irc0": [ "rlfilter0" ]
    },
    
    "outbound": {
      "quote0": [ "rlfilter1" ]
    }
  }
}
```

In this example, all messages flowing *to* agent `irc0` would first pass through `rlfilter0`. Similarly, all messages passing *from* module `quote0` would first pass through `rlfilter1`.

The admin decided to do this so that the Halibot instance can only send to any irc endpoints once every ten seconds. Furthermore, since `quote0` can be a somewhat spammy module, the admin specifically puts that module behind an outbound filter, so `quote0` can only reply once every ten minutes.

When a `!quote` command is received, both filters apply. That is, the reply message for the irc endpoint from `quote0` must successfully pass through `rlfilter1` **and** `rlfilter0`. The target RI generated is thus `rlfilter1/rlfilter0/irc0/##somechannel`.

Getting into more detail, the chain resolves thusly:
 - quote0 calls a send_to (via reply) targeting `irc0/##halibot`
 - HalObject.send_to injects `rlfilter1` and `rlfilter0`, so the new RI is `rlfilter1/rlfilter0/irc0/##halibot`
 - `rlfilter1` receives the message, accepts it, and sends to the new RI `rlfilter0/irc0/##halibot`
 - `rlfilter0` receives the message, accepts it, and sends to the new RI `irc0/##halibot`
 - `irc0` receives the message, and does the normal agenty thing
NOTE: in all cases, `msg.origin` *remains the same*: `quote0`.

# Draft Notes
As this is a draft, I am very aware at some lacking features, implementations etc. As of now, here are the tasks still needed to be completed:
- [ ] Add CLI support
- [ ] Implement an example filter
- [ ] Expand testing to support filter chains