### PR TITLE
Add MalformedMsgException to message.py for general error use

### DIFF
--- a/halibot/message.py
+++ b/halibot/message.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from .jsdict import jsdict
 
+class MalformedMsgException(Exception): 'Bad message object'
+
 class Message():
 
 	def __init__(self, **kwargs):


### PR DESCRIPTION
This has been brought up in other pull request discussions, so I'm opening a new PR to track the discussion here. #115  #131 and #132  may depend on this, and should be rebased if this is accepted.

This semi-general purpose exception is for consumers of Halibot messages to raise when there is an issue with a message object they received. In general, these exceptions should be raised when there is a grievous problem with the message that cannot be ignored. For example, this should be raised when an attribute is missing entirely (and thus would turn into an `AttributeError` if the code continues), or a field is empty, when it should not be (such as a blank `.target` for routing).

This Exception should NOT be thrown for simple validation, like bad command syntax in `msg.body`, or when a particular `msg.origin` RI does not exist.