### PR TITLE
Add default filter-instances entry in config

### DIFF
--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -186,7 +186,7 @@ class Halibot():
 			return None
 
 	def _instantiate_objects(self, key):
-		inst = self.config[key + "-instances"]
+		inst = self.config.get(key + "-instances", {})
 
 		for k in inst.keys():
 			conf = inst[k]

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ def h_init(args):
 		"repos": ["https://halibot.fish:4842"],
 		"agent-instances": {},
 		"module-instances": {},
+		"filter-instances": {},
 		"use-auth": False
 	}
 


### PR DESCRIPTION
Fixes this error when starting halibot:

Log level 'DEBUG'
Traceback (most recent call last):
  File "/usr/local/share/halibot/main.py", line 461, in <module>
    subcmds[args.cmd](args)
  File "/usr/local/share/halibot/main.py", line 105, in h_run
    bot.start(block=True)
  File "/usr/local/share/halibot/halibot/halibot.py", line 122, in start
    self._instantiate_objects("filter")
  File "/usr/local/share/halibot/halibot/halibot.py", line 189, in _instantiate_objects
    inst = self.config[key + "-instances"]
  File "/usr/local/share/halibot/halibot/halibot.py", line 80, in __getitem__
    return self.system[key]
KeyError: 'filter-instances'