### PR TITLE
Include instance name in object logger

### DIFF
--- a/halibot/halibot.py
+++ b/halibot/halibot.py
@@ -150,6 +150,7 @@ class Halibot():
 	def add_instance(self, name, inst):
 		self.objects[name] = inst
 		inst.name = name
+		inst.log.name += "({})".format(name)
 		inst.init()
 		self.log.info("Instantiated object '" + name + "'")
 

--- a/halibot/halobject.py
+++ b/halibot/halobject.py
@@ -14,7 +14,7 @@ class HalObject():
 	def __init__(self, hal, conf={}):
 		self._hal = hal
 		self.config = conf
-		self.log = logging.getLogger(self.__class__.__name__) # TODO: Put instantiated name in here too
+		self.log = logging.getLogger(self.__class__.__name__)
 
 		# Only used in HalModule.reply right now, but accessed on potentially any
 		# HalObject, so it exists on every HalObject to avoid attribute errors


### PR DESCRIPTION
Halibot can have multiple instances of the same object running, and therefore
it can be difficult to pinpoint which particular instance may be logging
errors.

This patch adds a small change to .add_instance() to append the instance
name to the object logger name.

This clears a `TODO` in HalObject, but the code itself went into core `halibot`. Feel free to counter the output format, or the location of where this should be applied. We don't set `.name` itself on the HalObject until `.add_instance()`, so it's probably the best fit.